### PR TITLE
development into master 1.11.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discrub-ext",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.4.3",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "Discrub",
   "name": "Discrub",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "description": "A data manipulation and export tool for Discord.",
   "manifest_version": 3,
   "permissions": [],

--- a/src/components/DiscrubDialog/About/changelog.json
+++ b/src/components/DiscrubDialog/About/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "1.11.6",
+    "changes": [
+      "Add optional skip for Message Reply Tags in the Tags screen (toggled by default).",
+      "Fix display name bug on 'Tags Received For User' Tags spreadsheet."
+    ]
+  },
+  {
     "version": "1.11.5",
     "changes": ["Add the ability to generate Channel tag data spreadsheets."]
   },

--- a/src/components/DiscrubDialog/DiscrubDialog.jsx
+++ b/src/components/DiscrubDialog/DiscrubDialog.jsx
@@ -107,7 +107,7 @@ function DiscrubDialog() {
           justifyContent="center"
           spacing={1}
         >
-          <Typography variant="body2">1.11.5</Typography>
+          <Typography variant="body2">1.11.6</Typography>
         </Stack>
       </Box>
       <CloseWindowButton />

--- a/src/containers/Tags/Tags.jsx
+++ b/src/containers/Tags/Tags.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import {
   Alert,
   Autocomplete,
@@ -59,6 +59,10 @@ function Tags() {
   const { token, isLoading: userLoading } = useSelector(selectUser);
   const { exportMaps } = useSelector(selectExport);
   const { userMap } = exportMaps;
+
+  // TODO: Create a tagSlice, so that we don't need to do this!
+  const userMapRef = useRef();
+  userMapRef.current = userMap;
 
   const { messageCount } = fetchProgress || {};
 
@@ -125,7 +129,8 @@ function Tags() {
         const { userMention } = dispatch(getSpecialFormatting(message.content));
         const author = message.getAuthor();
         const guildNickName =
-          userMap[author.getUserId()]?.guilds[selectedGuild.getId()]?.nick;
+          userMapRef.current[author.getUserId()]?.guilds[selectedGuild.getId()]
+            ?.nick;
 
         const displayName =
           guildNickName || author.getDisplayName() || author.getUserName();
@@ -140,9 +145,10 @@ function Tags() {
         const { userMention } = dispatch(getSpecialFormatting(message.content));
         if (Boolean(userMention?.length)) {
           userMention.forEach((mention) => {
-            const { userId, userName } = mention;
+            const { id: userId, userName } = mention;
             const guildNickName =
-              userMap[userId]?.guilds[selectedGuild.getId()]?.nick;
+              userMapRef.current[userId]?.guilds[selectedGuild.getId()]?.nick;
+
             const displayName = guildNickName || userName;
             mentionMap[displayName] = Number(mentionMap[displayName] || 0) + 1;
           });

--- a/src/containers/Tags/Tags.jsx
+++ b/src/containers/Tags/Tags.jsx
@@ -40,6 +40,7 @@ import {
   getSpecialFormatting,
   selectExport,
 } from "../../features/export/exportSlice";
+import SkipReplies from "./components/SkipReplies";
 
 function Tags() {
   const classes = TagsStyles();
@@ -68,12 +69,12 @@ function Tags() {
 
   const [anchorEl, setAnchorEl] = useState(null);
   const [noTagsFound, setNoTagsFound] = useState(false);
+  const [skipReplies, setSkipReplies] = useState(true);
 
   const pauseCancelDisabled = !messagesLoading;
   const guildFieldDisabled = messagesLoading || discrubCancelled;
   const channelFieldDisabled =
     selectedGuild.id === null || messagesLoading || discrubCancelled;
-  const dateFieldsDisabled = messagesLoading;
   const generateBtnDisabled =
     !selectedGuild.id ||
     messagesLoading ||
@@ -119,10 +120,14 @@ function Tags() {
 
   const handleGenerate = async (type = Tag.TAGS_MADE_BY_USER) => {
     setAnchorEl(null);
-    const { messages } = await dispatch(
+    let { messages } = await dispatch(
       getMessageData(selectedGuild.id, selectedChannel.id)
     );
     let mentionMap = {};
+
+    if (skipReplies) {
+      messages = messages.filter((message) => !message.isReply());
+    }
 
     if (type === Tag.TAGS_MADE_BY_USER) {
       messages.forEach((message) => {
@@ -275,7 +280,7 @@ function Tags() {
               />
             </Stack>
             <BeforeAndAfterFields
-              disabled={dateFieldsDisabled}
+              disabled={messagesLoading}
               afterProps={{
                 toolTipTitle: "Tags Starting From",
                 toolTipDescription:
@@ -288,6 +293,12 @@ function Tags() {
                 label: "Tags Ending On",
               }}
             />
+            <SkipReplies
+              messagesLoading={messagesLoading}
+              setSkipReplies={setSkipReplies}
+              skipReplies={skipReplies}
+            />
+
             <Stack
               alignItems="center"
               direction="row"

--- a/src/containers/Tags/Tags.styles.js
+++ b/src/containers/Tags/Tags.styles.js
@@ -21,6 +21,11 @@ const TagsStyles = makeStyles(() => ({
     marginTop: "1vh",
     flexDirection: "column",
   },
+  skipRepliesParent: {
+    backgroundColor: "rgb(32, 34, 37, 0.25)",
+    borderRadius: "15px",
+    padding: "8px",
+  },
 }));
 
 export default TagsStyles;

--- a/src/containers/Tags/components/SkipReplies.jsx
+++ b/src/containers/Tags/components/SkipReplies.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { IconButton, Stack, Typography } from "@mui/material";
+import DiscordTooltip from "../../../components/DiscordComponents/DiscordTooltip/DiscordToolTip";
+import PlaylistAddCheckIcon from "@mui/icons-material/PlaylistAddCheck";
+import PlaylistRemoveIcon from "@mui/icons-material/PlaylistRemove";
+import TagsStyles from "../Tags.styles";
+
+function SkipReplies({ skipReplies, messagesLoading, setSkipReplies }) {
+  const classes = TagsStyles();
+  return (
+    <Stack flexDirection="row" justifyContent="end">
+      <Stack className={classes.skipRepliesParent} alignItems="center">
+        <Typography variant="body2">Spreadsheet Options</Typography>
+        <DiscordTooltip
+          arrow
+          placement="left"
+          title={`${skipReplies ? "Skipping" : "Including"} Reply Tags`}
+          description={`Tags from message replies will ${
+            skipReplies ? "not" : ""
+          } be included in the generated spreadsheet`}
+        >
+          <IconButton
+            sx={{ maxWidth: "fit-content" }}
+            disabled={messagesLoading}
+            onClick={() => setSkipReplies(!skipReplies)}
+            color={skipReplies ? "secondary" : "primary"}
+          >
+            {skipReplies ? <PlaylistRemoveIcon /> : <PlaylistAddCheckIcon />}
+          </IconButton>
+        </DiscordTooltip>
+      </Stack>
+    </Stack>
+  );
+}
+
+export default SkipReplies;


### PR DESCRIPTION
Followup patch for #79 
This pull request adds the ability to skip Tags from message replies, when generating Tag spreadsheets.
This also fixes a display name bug for the 'Tags Received By User' spreadsheet option.