### PR TITLE
Make clean_prod_manifest portable on Alpine sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.12.11",
   "type": "module",
   "scripts": {
-    "clean_prod_manifest": "cat <<< $(jq 'del(.use_dynamic_url, .web_accessible_resources[].use_dynamic_url)' dist/manifest.json) > dist/manifest.json",
+    "clean_prod_manifest": "node ./scripts/clean-prod-manifest.mjs",
     "dev": "vite",
     "build": "tsc && vite build && npm run clean_prod_manifest",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/scripts/clean-prod-manifest.mjs
+++ b/scripts/clean-prod-manifest.mjs
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const manifestPath = path.resolve("dist", "manifest.json");
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+delete manifest.use_dynamic_url;
+
+if (Array.isArray(manifest.web_accessible_resources)) {
+  for (const resource of manifest.web_accessible_resources) {
+    if (resource && typeof resource === "object") {
+      delete resource.use_dynamic_url;
+    }
+  }
+}
+
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);


### PR DESCRIPTION
## Summary
- replace `clean_prod_manifest` shell/jq pipeline with a portable Node script
- remove dependency on bash-specific `<<<` redirection
- keep existing behavior: remove top-level `use_dynamic_url` and each `web_accessible_resources[].use_dynamic_url` from `dist/manifest.json`

## Why
The previous script failed on Alpine `/bin/sh` with:
- `sh: syntax error: unexpected redirection`

## Validation
- `npm run build` now exits successfully on Alpine after this change
- `clean_prod_manifest` executes via:
  - `node ./scripts/clean-prod-manifest.mjs`
