### PR TITLE
Add invite/emoji export workflows and fork-specific documentation

### DIFF
--- a/FORK-CHANGES.md
+++ b/FORK-CHANGES.md
@@ -1,0 +1,173 @@
+# Fork Changes
+
+This document compares the current local fork workspace in this repository against upstream `prathercc/discrub-ext`.
+
+## Comparison Basis
+
+- upstream reference in this repo: `origin/development`
+- upstream commit observed locally during this pass: `f3b1936` (`1.12.11`)
+- fork branch in this repo: `development`
+- fork commit on top of upstream: `88f0e80`
+
+The current workspace also contains additional uncommitted exporter refinements. Those are called out separately because they are part of the local fork state, but not all of them are in the committed fork delta yet.
+
+## Confirmed Committed Differences
+
+### 1. New menu-level exporters
+
+Upstream does not expose dedicated invite or emoji-export tools from the main menu. This fork adds two menu actions:
+
+- `Export Invites`
+- `Export Emojis`
+
+Evidence:
+
+- `src/containers/discrub-dialog/components/menu-bar.tsx`
+
+### 2. Invite exporter flow
+
+This fork adds a dedicated invite exporter dialog and Discord API helpers for invite discovery.
+
+Confirmed behavior from code:
+
+- scans all accessible guilds for the current authenticated account
+- tries vanity URL lookup first
+- falls back to guild metadata vanity code
+- falls back to guild widget invite
+- then falls back to channel invite creation and existing channel invites
+- normalizes output to `https://discord.gg/<code>`
+- writes a single plain-text export file
+- keeps per-guild success/error output in the dialog log
+- supports stop-on-close behavior while running
+
+Evidence:
+
+- `src/containers/invite-export-button/invite-export-button.tsx`
+- `src/services/discord-service.ts`
+
+### 3. Emoji exporter added on top of upstream
+
+Upstream does not include a dedicated menu-driven emoji/sticker exporter. This fork adds one.
+
+Committed fork behavior confirmed from code:
+
+- scans guild emoji data through guild API fetches
+- supports manifest import
+- persists resume state in extension storage
+- logs progress in a dedicated dialog
+- exports emoji assets with normalized filenames
+- uses additional Discord service methods and menu integration
+
+Evidence:
+
+- `src/containers/emoji-export-button/emoji-export-button.tsx`
+- `src/services/discord-service.ts`
+- `src/containers/discrub-dialog/components/menu-bar.tsx`
+
+### 4. Extension permissions changed for downloader use
+
+Relative to upstream, the fork adds:
+
+- `downloads` permission
+- `https://cdn.discordapp.com/*` host permission
+
+Evidence:
+
+- `public/manifest.json`
+
+## Additional Current Workspace Differences
+
+These are present in the local fork workspace now and were also corroborated by the session-log reference folder, but they are not all part of the single committed fork diff shown above.
+
+### 1. ZIP-first archive flow for emoji export
+
+The current local workspace replaces per-asset browser downloads with a ZIP-first archive pipeline.
+
+Confirmed behavior:
+
+- assets are written into one archive instead of downloaded one-by-one
+- archive logs are included in the ZIP
+- partial archives can still be finalized on stop
+- manifest files are added into the archive
+
+Evidence:
+
+- `src/features/export/archive-writer.ts`
+- `src/containers/emoji-export-button/emoji-export-button.tsx`
+
+### 2. Final format normalization
+
+The local workspace now distinguishes between transport format, detected binary format, animation state, and final exported format.
+
+Confirmed behavior:
+
+- static image output is normalized to `png`
+- animated output is normalized to `gif`
+- JSON/Lottie assets stay `json`
+- output naming uses the final normalized extension, not just the transport extension
+
+Evidence:
+
+- `src/containers/emoji-export-button/emoji-export-asset-format.ts`
+- `src/containers/emoji-export-button/emoji-export-postprocess.ts`
+- `src/containers/emoji-export-button/emoji-export-button.tsx`
+
+### 3. Animated emoji and sticker reliability fixes
+
+The session logs and current code both show that the fork had to work around Discord/CDN and browser-decoder issues.
+
+Confirmed current behavior:
+
+- animated emoji transport uses WebP fetches with `animated=true` instead of relying on direct `.gif` transport
+- animation is detected from file bytes, not only runtime decoder metadata
+- animated PNG/APNG stickers are routed through the same finalization logic as animated emoji
+- per-asset format-processing failures are logged and skipped instead of crashing the whole export
+
+Evidence:
+
+- `src/containers/emoji-export-button/emoji-export-asset-format.ts`
+- `src/containers/emoji-export-button/emoji-export-button.tsx`
+- `CC-Session-Logs-and-readme-of-fork/13-04-2026-08_35-emoji-export-fixes.md`
+- `CC-Session-Logs-and-readme-of-fork/13-04-2026-11_46-emoji-export-fixes-and-docs.md`
+
+### 4. Website-style naming and meta-file generation
+
+The current workspace adds website-oriented postprocessing for downstream ingestion.
+
+Confirmed behavior:
+
+- exported assets use a website-style naming convention
+- optional meta-file generation can emit manifest/helper files
+- renamed-file metadata is derived from finalized asset output
+
+Evidence:
+
+- `src/containers/emoji-export-button/emoji-export-postprocess.ts`
+- `src/containers/emoji-export-button/emoji-export-button.tsx`
+
+### 5. Exporter UI and workflow refinements
+
+Confirmed current local UI changes:
+
+- emoji exporter has worker-count control
+- emoji exporter can include stickers in the same run
+- emoji exporter can clear imported manifest and resume state
+- exporter log viewport is denser and larger
+- invite exporter log styling was adjusted to match the emoji exporter
+- emoji exporter resets local dialog state on close when not exporting
+
+Evidence:
+
+- `src/containers/emoji-export-button/emoji-export-button.tsx`
+- `src/containers/invite-export-button/invite-export-button.tsx`
+- `CC-Session-Logs-and-readme-of-fork/13-04-2026-11_46-emoji-export-fixes-and-docs.md`
+
+## Not Claimed As Confirmed
+
+The reference logs explicitly mention ideas that are not documented here as confirmed fork scope unless they are backed by code:
+
+- native helpers
+- shell-side post-processing
+- EXIF tagging
+
+Those are intentionally excluded from the fork description because they are not supported by the current repository state.

--- a/README.md
+++ b/README.md
@@ -1,57 +1,98 @@
+# Discrub Fork
 
-# <img width="45px" src="https://github.com/prathercc/discrub-ext/raw/master/public/resources/media/discrub.png"> Discrub
+This repository is a fork of [`prathercc/discrub-ext`](https://github.com/prathercc/discrub-ext). It keeps the upstream Discord message tooling, but extends the project with fork-specific export workflows aimed at bulk archival and asset extraction.
 
-**Discrub** is a Google Chrome extension that is used to Edit/Delete, Sort/Filter, and Export (HTML, CSV, and JSON supported) Discord messages.
+This README is fork-specific. It documents the current local fork state in this repository, not just upstream Discrub.
 
-#### The latest version of this extension can be found here:
-- https://chrome.google.com/webstore/detail/discrub/plhdclenpaecffbcefjmpkkbdpkmhhbj
- - https://addons.mozilla.org/en-US/firefox/addon/discrub/
+## Why This Fork Exists
 
-#### Historical releases can be found here: 
- - https://github.com/prathercc/discrub-ext/releases
+Upstream Discrub already covers message search, filtering, export, and purge workflows well. This fork exists because the local use case pushed harder on:
 
+- invite discovery across accessible guilds
+- bulk emoji and sticker extraction
+- browser-side packaging for very large exports
+- predictable final asset formats instead of transport-format leaks
+- exporter UX that stays usable during long runs
 
+## What's Different In This Fork
 
-## Quick Start Guide
- - [Opening the Extension / Authentication](https://github.com/prathercc/discrub-ext/blob/development/docs/opening_the_extension_and_authentication.md)
- - [Navigating Discrub](https://github.com/prathercc/discrub-ext/blob/development/docs/navigating_discrub.md)
- - [Configuring the Search Criteria](https://github.com/prathercc/discrub-ext/blob/development/docs/configuring_the_search_criteria.md)
- - Loading and Manipulating Messages
-	 - [Selecting and Loading a Channel/DM](https://github.com/prathercc/discrub-ext/blob/development/docs/loading_and_manipulating_messages/selecting_and_loading_a_channel_or_dm.md)
-	-   [Manually Load a Thread or Forum Post](https://github.com/prathercc/discrub-ext/blob/development/docs/loading_and_manipulating_messages/manually_load_thread_or_fourm_post.md)
-	-   [Copy Server/Channel/DM List](https://github.com/prathercc/discrub-ext/blob/development/docs/loading_and_manipulating_messages/copy_a_server_channel_dm_list.md)
-	-   [Copy a Users ID](https://github.com/prathercc/discrub-ext/blob/development/docs/loading_and_manipulating_messages/copy_a_users_id.md)
-	-   [Quick Filtering](https://github.com/prathercc/discrub-ext/blob/development/docs/loading_and_manipulating_messages/quick_filtering.md)
-	-   [Export Loaded Messages](https://github.com/prathercc/discrub-ext/blob/development/docs/loading_and_manipulating_messages/export_loaded_messages.md)
-	-   [View/Delete Attachments](https://github.com/prathercc/discrub-ext/blob/development/docs/loading_and_manipulating_messages/view_or_delete_attachments.md)
-	-   [View/Delete Reactions](https://github.com/prathercc/discrub-ext/blob/development/docs/loading_and_manipulating_messages/view_or_delete_reactions.md)
-	-   [View Rich Embeds](https://github.com/prathercc/discrub-ext/blob/development/docs/loading_and_manipulating_messages/view_rich_embeds.md)
-	-   [Edit Message Content](https://github.com/prathercc/discrub-ext/blob/development/docs/loading_and_manipulating_messages/edit_message_content.md)
-	- [Delete Message Data](https://github.com/prathercc/discrub-ext/blob/development/docs/loading_and_manipulating_messages/delete_message_data.md)
-- [Export a Server](https://github.com/prathercc/discrub-ext/blob/development/docs/export_a_server.md)
-- [Export DMs](https://github.com/prathercc/discrub-ext/blob/development/docs/export_a_dm.md)
-- [Purge a Server / DM](https://github.com/prathercc/discrub-ext/blob/development/docs/purge_a_server_or_dm.md)
-- [Tags](https://github.com/prathercc/discrub-ext/blob/development/docs/tags.md)
-- [Settings](https://github.com/prathercc/discrub-ext/blob/development/docs/settings.md)
+### Invite exporter
 
+The fork adds an **Export Invites** action in the menu. It scans guilds visible to the authenticated account and tries several invite sources before giving up:
 
-## FAQ
+1. guild vanity URL endpoint
+2. guild data fallback vanity code
+3. guild widget invite
+4. channel invite creation
+5. existing channel invites
 
- - [How can I prevent reaction data from being looked up? Message searches are taking too long!](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/prevent_reaction_lookups.md)
- - [Discord keeps rate limiting me, how can I increase the time between deletions/edits/searches?](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/prevent_rate_limits.md)
- - [Why am I getting a Missing Permissions error message when modifying messages?](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/missing_permission.md)
- - [How can I remove messages from a blocked User's DM?](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/removed_blocked_user_dm_messages.md)
- - [Does Discrub work on mobile?](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/discrub_on_mobile.md)
- - [Where can I find a list of all calls that I've made to another User in a DM?](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/call_messages.md)
- - [Exporting a Server/DM appears to be taking a long time without any visible progress, what is happening?](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/long_export_time.md)
- - [Why isn't Discrub opening?](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/discrub_not_opening.md)
- - [Why am I getting an Authentication Token screen?](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/failure_to_authenticate.md)
- - [What can I do with the data package provided by Discord?](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/discord_data_package.md)
- - [Can I import messages into a Server using this extension?](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/import_messages.md)
- - [How far back will this extension work for saving and searching messages?](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/how_far_back.md)
- - [Why isn't Discrub letting me manually load a User by their username?](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/not_allowing_manual_load_of_username.md)
- - [How can I load messages for a specific Thread or Forum Post only?](https://github.com/prathercc/discrub-ext/blob/development/docs/faq/load_thread_or_forum_post.md)
+Results are normalized to `https://discord.gg/<code>` and saved as a plain-text report with per-guild success or failure entries.
 
-## Contributing
+See [docs/export_invites.md](./docs/export_invites.md).
 
-Feel free to create an [Issue](https://github.com/prathercc/discrub-ext/issues) if you have any ideas for improvement or notice any bugs that need to addressed.
+### Emoji and sticker exporter
+
+The fork adds an **Export Emojis** action in the menu. The current local fork state replaces per-asset browser downloads with a ZIP-first archive flow and adds several reliability fixes around Discord asset transport:
+
+- worker-pool processing across guilds
+- optional sticker inclusion
+- optional meta-file generation for downstream website ingestion
+- resume/checkpoint state stored in extension storage
+- archive log output
+- manifest import and partial-manifest recovery
+- website-style asset filenames
+
+The exporter also normalizes final output instead of trusting the original transport extension:
+
+- static image assets end as real `png`
+- animated image assets end as real `gif`
+- JSON/Lottie assets stay `json`
+
+See [docs/export_emojis.md](./docs/export_emojis.md).
+
+### Exporter workflow and UI changes
+
+Confirmed fork-specific UI and workflow changes include:
+
+- extra menu entries for invite and emoji export
+- denser exporter dialogs with larger log viewports
+- smaller monospace log rows to fit more progress output
+- cleaner progress and error reporting
+- emoji exporter state reset on close when idle, so reopening starts clean
+
+## Build And Load
+
+This fork is set up for local build and unpacked Chrome loading.
+
+```bash
+npm install
+npm run build
+```
+
+Then open `chrome://extensions`, enable **Developer mode**, choose **Load unpacked**, and select the built `dist/` directory.
+
+## Documentation
+
+Fork-specific docs:
+
+- [FORK-CHANGES.md](./FORK-CHANGES.md) - direct fork delta vs upstream
+- [docs/export_invites.md](./docs/export_invites.md) - invite exporter behavior and limitations
+- [docs/export_emojis.md](./docs/export_emojis.md) - emoji/sticker exporter workflow, options, and archive layout
+
+Core upstream-style docs that still apply to the base product:
+
+- [Opening the Extension / Authentication](./docs/opening_the_extension_and_authentication.md)
+- [Navigating Discrub](./docs/navigating_discrub.md)
+- [Configuring the Search Criteria](./docs/configuring_the_search_criteria.md)
+- [Export a Server](./docs/export_a_server.md)
+- [Export DMs](./docs/export_a_dm.md)
+- [Purge a Server / DM](./docs/purge_a_server_or_dm.md)
+- [Settings](./docs/settings.md)
+
+## Upstream Credit
+
+Credit for the original project, architecture, and core Discord message tooling belongs to the upstream project and maintainer:
+
+- upstream repository: [`prathercc/discrub-ext`](https://github.com/prathercc/discrub-ext)
+
+This fork is a derivative maintenance branch with additional export tooling and workflow changes on top of that base.

--- a/docs/export_emojis.md
+++ b/docs/export_emojis.md
@@ -1,0 +1,97 @@
+## Export Emojis
+
+This fork adds a dedicated **Export Emojis** dialog in the main menu. It is separate from message export and is focused on guild emoji and sticker extraction.
+
+## What It Exports
+
+The current local fork state can export:
+
+- emoji only
+- emoji plus stickers
+
+The exporter scans guild asset data for the currently authenticated account, downloads eligible assets, normalizes output formats, and packages the result into one archive.
+
+## Current Workflow
+
+The current local workspace uses a ZIP-first flow rather than triggering one browser download per asset.
+
+Confirmed current behavior:
+
+- one archive per export run
+- archive log file included in the package
+- manifest written into the package
+- partial archive generation if the run is stopped
+- resume/checkpoint state stored in extension storage
+- manifest import before export
+
+## Dialog Options
+
+The exporter currently exposes these controls:
+
+- **Import Manifest** - load a previously exported or partial manifest and seed the run from it
+- **Clear Manifest** - clear imported manifest data and remove saved resume state
+- **Workers** - number of guild workers used for parallel processing
+- **Generate Meta Files** - emit website-oriented helper files in addition to the manifest
+- **Include Stickers** - include sticker assets in the same run as emoji
+
+These controls are local to the exporter dialog. They are not part of the persistent global Settings page.
+
+## Final Output Rules
+
+The current workspace does not blindly trust the transport extension used to fetch assets. It detects the real binary format and animation state, then writes a normalized final file.
+
+Current rules:
+
+- static image assets -> `png`
+- animated image assets -> `gif`
+- JSON/Lottie assets -> `json`
+
+That rule applies to emoji and stickers in the current exporter implementation.
+
+## Why The Finalization Step Exists
+
+The exporter had to work around practical Discord/browser issues that showed up during fork development:
+
+- direct animated emoji `.gif` transport was unreliable in the tested flow
+- animation state could not safely be inferred from filename alone
+- browser/runtime metadata was not reliable enough for some animated assets
+
+The current local exporter therefore:
+
+- fetches animated emoji through a WebP transport path when needed
+- inspects asset bytes to determine actual format and frame structure
+- routes animated output through local GIF finalization
+
+## Archive Layout
+
+The exact archive contents can vary depending on options, but the current exporter writes data in a structure centered around:
+
+- exported asset files
+- manifest JSON
+- optional meta/helper files
+- export log text file
+
+When meta generation is enabled, helper files are written under a dedicated metadata area in the archive.
+
+## Naming
+
+The current workspace applies website-style filenames to exported assets. Naming is derived from the finalized asset type and extension, not just from the download transport format.
+
+## Resume Behavior
+
+Resume state is stored in extension storage and includes:
+
+- next guild checkpoint
+- completed guild IDs
+- seen asset keys
+- manifest entries
+- whether meta generation was enabled
+
+If the saved resume state does not match the current meta-generation mode, the exporter ignores that resume state instead of mixing incompatible runs.
+
+## Limits And Caveats
+
+- The exporter only sees emoji/stickers available through the authenticated account's accessible guild list.
+- Permission failures are logged and counted, not treated as proof that a guild has no assets.
+- Per-asset conversion failures are logged and skipped so one bad asset does not kill the whole export.
+- This is fork-specific functionality and does not exist in upstream `prathercc/discrub-ext`.

--- a/docs/export_invites.md
+++ b/docs/export_invites.md
@@ -1,0 +1,52 @@
+## Export Invites
+
+This fork adds a dedicated **Export Invites** dialog in the main menu. It is separate from message export and is meant for invite discovery across guilds visible to the currently authenticated Discord account.
+
+## What It Does
+
+The exporter walks the guild list and tries to resolve one useful invite per guild. Output is written as a single plain-text file.
+
+The code currently uses this fallback order:
+
+1. guild vanity URL endpoint
+2. vanity code returned from guild data
+3. widget invite from `widget.json`
+4. invite creation on candidate channels
+5. existing invites on candidate channels
+
+All successful results are normalized into `https://discord.gg/<code>`.
+
+## Export Flow
+
+When you run the exporter:
+
+- the dialog opens from **Menu -> Export Invites**
+- the exporter scans every loaded guild available to the current token
+- progress and errors are written into the on-screen log
+- the final result is downloaded as one `.txt` file
+
+If the dialog is closed while export is running, the button switches into a stop request and the exporter finishes the current step before exiting.
+
+## Output Format
+
+The exported text file contains:
+
+- generation timestamp
+- total guild count
+- success/failure summary
+- one section per guild
+
+Successful entries include the resolved invite URL. Failed entries record a short reason such as `no permission`, `no invite found`, or `unknown error on channels`.
+
+## Channel Selection Notes
+
+The exporter only tests channel types that can plausibly host invites. Text-like channels are tried first, then other supported guild channel types.
+
+There is also an early-stop rule for repeated permission failures so the exporter does not waste time walking a large number of inaccessible channels in a guild.
+
+## Limits And Caveats
+
+- The exporter only sees what the authenticated account can see.
+- It cannot recover invites where the account lacks access to every usable source.
+- Some guilds will report `no permission` or `no invite found` even when the guild itself is visible.
+- The exporter is intentionally practical: it aims for one usable invite per guild, not a full invite inventory.

--- a/docs/navigating_discrub.md
+++ b/docs/navigating_discrub.md
@@ -9,4 +9,9 @@ The top left Menu button provides the ability to navigate through the extensions
  - **Tags** - Generate a spreadsheet with the number of tags made by Users in Server Channels.
  - **Change Log** - View historical changes made to Discrub.
  - **Settings** - Broadly customize the extensions behavior.
+ 
+#### Fork-specific menu actions:
+ - **Export Invites** - Run the fork-specific invite discovery/export workflow across the guilds visible to the authenticated account.
+ - **Export Emojis** - Run the fork-specific emoji or emoji+sticker exporter with archive packaging, logging, and resume support.
+ - **Magikownia Discord** - Open the fork maintainer's Discord link from the menu.
  - **Reddit** - Open the extensions support page.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -13,6 +13,8 @@ Settings are used by the extension to customize your experience, and they can be
 
 **Note:** The values entered for these settings will persist for each session, so you **will not** need to re-enter these each time you use Discrub.
 
+Fork note: the dedicated **Export Invites** and **Export Emojis** dialogs introduced in this fork also have their own local controls. Those are not part of the persistent global Settings page documented below. See [export_invites.md](./export_invites.md) and [export_emojis.md](./export_emojis.md).
+
 Below is an overview of each possible setting and what behavior it defines:
 
  - **Fetch Reaction Data** - Determine if the extension should attempt to lookup Reaction data for any messages that are found during searches.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discrub-ext",
-  "version": "1.11.6",
+  "version": "1.12.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discrub-ext",
-      "version": "1.11.6",
+      "version": "1.12.11",
       "dependencies": {
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
@@ -16,17 +16,27 @@
         "@reduxjs/toolkit": "^2.0.1",
         "@transcend-io/conflux": "^4.1.0",
         "@types/chrome": "^0.0.256",
+        "@types/firefox-webext-browser": "^120.0.4",
         "bytes": "^3.1.2",
+        "classnames": "^2.5.1",
         "copy-to-clipboard": "^3.3.3",
         "date-fns": "^3.1.0",
+        "date-fns-tz": "^3.2.0",
         "debounce": "^2.0.0",
+        "file-type": "^21.0.0",
+        "filenamify": "^6.0.0",
+        "flat": "^6.0.1",
+        "gifenc": "^1.0.3",
+        "highlight.js": "^11.10.0",
+        "nanoid": "^5.1.5",
         "papaparse": "^5.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-markdown": "^10.1.0",
         "react-redux": "^9.0.4",
         "react-to-print": "^2.14.15",
-        "streamsaver": "^2.0.6",
-        "uuid": "^9.0.1"
+        "react-window": "^1.8.10",
+        "streamsaver": "^2.0.6"
       },
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.0.0-beta.21",
@@ -34,6 +44,7 @@
         "@types/papaparse": "^5.3.14",
         "@types/react": "^18.2.47",
         "@types/react-dom": "^18.2.17",
+        "@types/react-window": "^1.8.8",
         "@types/uuid": "^9.0.7",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
@@ -41,6 +52,7 @@
         "eslint": "^8.55.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
+        "prettier": "3.3.3",
         "typescript": "^5.2.2",
         "vite": "^4.5.0"
       }
@@ -68,12 +80,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -265,17 +279,19 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -290,37 +306,28 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.6.tgz",
-      "integrity": "sha512-wCfsbN4nBidDRhpDhvcKlzHWCTlgJYUUdSJfzXb2NuBssDSIjc3xcb+znA7l+zYsFljAcGM0aFkN40cR3lXiGA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.6",
-        "@babel/types": "^7.23.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
-      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -359,37 +366,36 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
-      "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.23.7.tgz",
-      "integrity": "sha512-ER55qzLREVA5YxeyQ3Qu48tgsF2ZrFjFjUS6V6wF0cikSw+goBJgB9PBRM1T6+Ah4iiM+sxmfS/Sy/jdzFfhiQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+      "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
+      "license": "MIT",
       "dependencies": {
-        "core-js-pure": "^3.30.2",
-        "regenerator-runtime": "^0.14.0"
+        "core-js-pure": "^3.48.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -417,40 +423,54 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/@crxjs/vite-plugin": {
-      "version": "2.0.0-beta.21",
-      "resolved": "https://registry.npmjs.org/@crxjs/vite-plugin/-/vite-plugin-2.0.0-beta.21.tgz",
-      "integrity": "sha512-kSXgHHqCXASqJ8NmY94+KLGVwdtkJ0E7KsRQ+vbMpRliJ5ze0xnSk0l41p4txlUysmEoqaeo4Xb7rEFdcU2zjQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@crxjs/vite-plugin/-/vite-plugin-2.4.0.tgz",
+      "integrity": "sha512-bDLdq0W2V1SkMQDJjrcYyjK9/uKtdl4joT7GRImcootCjZdKRiRYt+cv9z8tJoU/tK3o1lX48LTqN7JMsk5AQg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^4.1.2",
         "@webcomponents/custom-elements": "^1.5.0",
         "acorn-walk": "^8.2.0",
-        "cheerio": "^1.0.0-rc.10",
-        "connect-injector": "^0.4.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.3.3",
         "es-module-lexer": "^0.10.0",
         "fast-glob": "^3.2.11",
         "fs-extra": "^10.0.1",
         "jsesc": "^3.0.2",
-        "magic-string": "^0.26.0",
-        "picocolors": "^1.0.0",
+        "magic-string": "^0.30.12",
+        "node-html-parser": "^7.0.2",
+        "pathe": "^2.0.1",
+        "picocolors": "^1.1.1",
         "react-refresh": "^0.13.0",
-        "rollup": "2.78.1",
+        "rollup": "2.79.2",
         "rxjs": "7.5.7"
+      },
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@crxjs/vite-plugin/node_modules/convert-source-map": {
@@ -481,10 +501,11 @@
       }
     },
     "node_modules/@crxjs/vite-plugin/node_modules/rollup": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -1167,10 +1188,11 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.20",
@@ -1572,6 +1594,29 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@transcend-io/conflux": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@transcend-io/conflux/-/conflux-4.1.0.tgz",
@@ -1639,6 +1684,30 @@
         "@types/har-format": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/filesystem": {
       "version": "0.0.35",
       "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.35.tgz",
@@ -1652,16 +1721,46 @@
       "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.32.tgz",
       "integrity": "sha512-Kpi2GXQyYJdjL8mFclL1eDgihn1SIzorMZjD94kdPZh9E4VxGOeyjPxi5LpsM4Zku7P0reqegZTt2GxhmA9VBg=="
     },
+    "node_modules/@types/firefox-webext-browser": {
+      "version": "120.0.5",
+      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-120.0.5.tgz",
+      "integrity": "sha512-imn8ecga0HQWcOSvxy9i0lD+7vpHgkj1NVLvXS1lNHqHt03Z4QwazeEdoWe+C9JXpmVyKiRanb+z9D/w001tRg==",
+      "license": "MIT"
+    },
     "node_modules/@types/har-format": {
       "version": "1.2.15",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.15.tgz",
       "integrity": "sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA=="
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.11.5",
@@ -1718,6 +1817,16 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
@@ -1728,6 +1837,12 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -1932,8 +2047,7 @@
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.2.1",
@@ -1991,10 +2105,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2013,17 +2128,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/argparse": {
@@ -2055,6 +2159,16 @@
         "npm": ">=6"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2065,25 +2179,28 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2157,56 +2274,61 @@
         }
       ]
     },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cheerio": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-      "dev": true,
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "htmlparser2": "^8.0.1",
-        "parse5": "^7.0.0",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
       "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/cheerio-select": {
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
       "funding": {
-        "url": "https://github.com/sponsors/fb55"
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/clsx": {
       "version": "2.1.0",
@@ -2216,53 +2338,20 @@
         "node": ">=6"
       }
     },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
-    },
-    "node_modules/connect-injector": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/connect-injector/-/connect-injector-0.4.4.tgz",
-      "integrity": "sha512-hdBG8nXop42y2gWCqOV8y1O3uVk4cIU+SoxLCPyCUKRImyPiScoNiSulpHjoktRU1BdI0UzoUdxUa87thrcmHw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^2.0.0",
-        "q": "^1.0.1",
-        "stream-buffers": "^0.2.3",
-        "uberproto": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/connect-injector/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/connect-injector/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
     "node_modules/convert-source-map": {
@@ -2280,10 +2369,11 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.35.0.tgz",
-      "integrity": "sha512-f+eRYmkou59uh7BPcyJ8MC76DiGhspj1KMxVIcF24tzP8NA9HVa1uC7BTW2tgx7E1QVCzDzsgp7kArrzhlz8Ew==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -2305,10 +2395,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2319,10 +2410,11 @@
       }
     },
     "node_modules/css-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -2335,10 +2427,11 @@
       }
     },
     "node_modules/css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
       },
@@ -2360,6 +2453,15 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
+      }
+    },
     "node_modules/debounce": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.0.0.tgz",
@@ -2372,12 +2474,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2388,11 +2490,46 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -2432,6 +2569,7 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -2451,13 +2589,15 @@
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ]
+      ],
+      "license": "BSD-2-Clause"
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -2469,10 +2609,11 @@
       }
     },
     "node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -2493,6 +2634,7 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -2558,14 +2700,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/eslint": {
@@ -2819,6 +2953,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -2833,6 +2977,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2901,11 +3051,57 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2934,6 +3130,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/flat": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-6.0.1.tgz",
+      "integrity": "sha512-/3FfIa8mbrg3xE7+wAhWeV+bd7L2Mof+xtZb5dRDKZ+wDvYJK4WDYeIOuOhre5Yv5aQObZrlbRmk3RTSiuQBtw==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -2949,10 +3157,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -3004,6 +3213,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/gifenc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
+      "integrity": "sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -3078,14 +3293,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
@@ -3095,6 +3302,65 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -3110,24 +3376,35 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-      "dev": true,
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
         {
           "type": "github",
-          "url": "https://github.com/sponsors/fb55"
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
         }
       ],
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
-      }
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.0",
@@ -3187,6 +3464,36 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3201,6 +3508,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -3224,11 +3541,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -3240,6 +3568,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -3254,10 +3594,11 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3377,6 +3718,16 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3398,16 +3749,173 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.26.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
-      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      },
-      "engines": {
-        "node": ">=12"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3418,13 +3926,456 @@
         "node": ">= 8"
       }
     },
-    "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -3432,10 +4383,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3444,27 +4396,27 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true,
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -3472,6 +4424,17 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/node-html-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
+      "integrity": "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.14",
@@ -3484,6 +4447,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -3576,6 +4540,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -3591,31 +4580,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
-      "dependencies": {
-        "entities": "^4.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-      "dev": true,
-      "dependencies": {
-        "domhandler": "^5.0.2",
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -3658,17 +4622,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -3704,6 +4676,25 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3711,6 +4702,22 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {
@@ -3728,6 +4735,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3735,16 +4752,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
       }
     },
     "node_modules/queue-microtask": {
@@ -3794,6 +4801,33 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.0.4",
@@ -3854,6 +4888,23 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -3867,10 +4918,38 @@
         "redux": "^5.0.0"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/reselect": {
       "version": "5.0.1",
@@ -3927,10 +5006,11 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.30.0.tgz",
+      "integrity": "sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -4062,20 +5142,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true
-    },
-    "node_modules/stream-buffers": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-0.2.6.tgz",
-      "integrity": "sha512-ZRpmWyuCdg0TtNKk8bEqvm13oQvXMmzXDsfD4cBgcx5LouborvU5pm3JMkdTP3HcszyUI08AM1dHMXA5r2g6Sg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.3.0"
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/streamsaver": {
@@ -4088,6 +5162,20 @@
           "url": "https://github.com/sponsors/jimmywarting"
         }
       ]
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -4113,21 +5201,44 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
-    },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -4146,19 +5257,12 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -4170,6 +5274,44 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
@@ -4226,13 +5368,16 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uberproto": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/uberproto/-/uberproto-1.2.0.tgz",
-      "integrity": "sha512-pGtPAQmLwh+R9w81WVHzui1FfedpQWQpiaIIfPCwhtsBez4q6DYbJFfyXPVHPUTNFnedAvNEnkoFiLuhXIR94w==",
-      "dev": true,
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/undici-types": {
@@ -4240,6 +5385,93 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -4297,23 +5529,40 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.14.tgz",
+      "integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -4400,9 +5649,10 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
       "engines": {
         "node": ">= 6"
       }
@@ -4417,6 +5667,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "file-type": "^21.0.0",
     "filenamify": "^6.0.0",
     "flat": "^6.0.1",
+    "gifenc": "^1.0.3",
     "highlight.js": "^11.10.0",
     "nanoid": "^5.1.5",
     "papaparse": "^5.4.1",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,8 @@
   "version": "1.12.11",
   "description": "A data manipulation and export tool for Discord.",
   "manifest_version": 3,
-  "permissions": ["storage"],
+  "permissions": ["storage", "downloads"],
+  "host_permissions": ["https://cdn.discordapp.com/*"],
   "background": {
     "service_worker": "public/resources/js/background.js",
     "type": "module"

--- a/src/containers/discrub-dialog/components/menu-bar.tsx
+++ b/src/containers/discrub-dialog/components/menu-bar.tsx
@@ -17,9 +17,14 @@ import MenuIcon from "@mui/icons-material/Menu";
 import MenuOpenIcon from "@mui/icons-material/MenuOpen";
 import RedditIcon from "@mui/icons-material/Reddit";
 import LoyaltyIcon from "@mui/icons-material/Loyalty";
+import LinkIcon from "@mui/icons-material/Link";
+import EmojiEmotionsIcon from "@mui/icons-material/EmojiEmotions";
+import ForumIcon from "@mui/icons-material/Forum";
 import { useExportSlice } from "../../../features/export/use-export-slice";
 import { useAppSlice } from "../../../features/app/use-app-slice";
 import { useMessageSlice } from "../../../features/message/use-message-slice";
+import InviteExportButton from "../../invite-export-button/invite-export-button.tsx";
+import EmojiExportButton from "../../emoji-export-button/emoji-export-button.tsx";
 
 const MenuBar = ({
   menuIndex,
@@ -43,6 +48,12 @@ const MenuBar = ({
 
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | Maybe>(null);
   const menuOpen = !!anchorEl;
+  const [inviteOpenSignal, setInviteOpenSignal] = useState<number | undefined>(
+    undefined,
+  );
+  const [emojiOpenSignal, setEmojiOpenSignal] = useState<number | undefined>(
+    undefined,
+  );
 
   const menuItems = [
     { name: "Channel Messages", icon: <ChatIcon /> },
@@ -130,6 +141,40 @@ const MenuBar = ({
         <Divider />
         <MenuItem
           onClick={() => {
+            setInviteOpenSignal((prevState) => (prevState ?? 0) + 1);
+            setAnchorEl(null);
+          }}
+        >
+          <ListItemIcon>
+            <LinkIcon />
+          </ListItemIcon>
+          <ListItemText>Export Invites</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            setEmojiOpenSignal((prevState) => (prevState ?? 0) + 1);
+            setAnchorEl(null);
+          }}
+        >
+          <ListItemIcon>
+            <EmojiEmotionsIcon />
+          </ListItemIcon>
+          <ListItemText>Export Emojis</ListItemText>
+        </MenuItem>
+        <Divider />
+        <MenuItem
+          onClick={() => {
+            window.open("https://discord.gg/magikownia", "_blank");
+            setAnchorEl(null);
+          }}
+        >
+          <ListItemIcon>
+            <ForumIcon />
+          </ListItemIcon>
+          <ListItemText>Magikownia Discord</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
             window.open("https://www.reddit.com/r/discrub/", "_blank");
             setAnchorEl(null);
           }}
@@ -140,6 +185,8 @@ const MenuBar = ({
           <ListItemText>Reddit</ListItemText>
         </MenuItem>
       </Menu>
+      <InviteExportButton showTrigger={false} openSignal={inviteOpenSignal} />
+      <EmojiExportButton showTrigger={false} openSignal={emojiOpenSignal} />
     </Box>
   );
 };

--- a/src/containers/emoji-export-button/emoji-export-asset-format.ts
+++ b/src/containers/emoji-export-button/emoji-export-asset-format.ts
@@ -1,0 +1,500 @@
+import { GIFEncoder, applyPalette, quantize } from "gifenc";
+
+export type AssetBinaryFormat = "png" | "gif" | "webp" | "json" | "unknown";
+export type ExportAssetType = "emoji" | "sticker";
+
+export type SniffedAssetInfo = {
+  detectedExt: AssetBinaryFormat;
+  isAnimated: boolean;
+  frameCount: number;
+};
+
+export type FinalizedAssetInfo = {
+  detectedExt: AssetBinaryFormat;
+  finalExt: AssetBinaryFormat;
+  isAnimated: boolean;
+  finalBlob: Blob;
+};
+
+const normalizeAssetExt = (ext: string) =>
+  String(ext || "").replace(/^\.+/, "").toLowerCase();
+
+const hasRiffWebpHeader = (bytes: Uint8Array) =>
+  bytes.length >= 12 &&
+  bytes[0] === 0x52 &&
+  bytes[1] === 0x49 &&
+  bytes[2] === 0x46 &&
+  bytes[3] === 0x46 &&
+  bytes[8] === 0x57 &&
+  bytes[9] === 0x45 &&
+  bytes[10] === 0x42 &&
+  bytes[11] === 0x50;
+
+const countAnimatedWebpFrames = (bytes: Uint8Array) => {
+  if (!hasRiffWebpHeader(bytes)) return 0;
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let frameCount = 0;
+  for (let offset = 12; offset + 8 <= bytes.byteLength; ) {
+    const fourCC = String.fromCharCode(
+      bytes[offset],
+      bytes[offset + 1],
+      bytes[offset + 2],
+      bytes[offset + 3],
+    );
+    const chunkSize = view.getUint32(offset + 4, true);
+    if (fourCC === "ANMF") {
+      frameCount += 1;
+    }
+    offset += 8 + chunkSize + (chunkSize % 2);
+  }
+
+  return frameCount;
+};
+
+export const detectAnimatedWebpBytes = (bytes: Uint8Array) => {
+  return countAnimatedWebpFrames(bytes) > 1;
+};
+
+export const detectAnimatedWebp = async (blob: Blob) =>
+  detectAnimatedWebpBytes(new Uint8Array(await blob.arrayBuffer()));
+
+const countGifFrames = (bytes: Uint8Array) => {
+  if (
+    bytes.length < 6 ||
+    bytes[0] !== 0x47 ||
+    bytes[1] !== 0x49 ||
+    bytes[2] !== 0x46 ||
+    bytes[3] !== 0x38 ||
+    (bytes[4] !== 0x37 && bytes[4] !== 0x39) ||
+    bytes[5] !== 0x61
+  ) {
+    return 0;
+  }
+
+  let frameCount = 0;
+  for (let index = 0; index < bytes.length; index += 1) {
+    if (bytes[index] === 0x2c) {
+      frameCount += 1;
+    }
+  }
+
+  return frameCount;
+};
+
+const countPngFrames = (bytes: Uint8Array) => {
+  if (
+    bytes.length < 8 ||
+    bytes[0] !== 0x89 ||
+    bytes[1] !== 0x50 ||
+    bytes[2] !== 0x4e ||
+    bytes[3] !== 0x47 ||
+    bytes[4] !== 0x0d ||
+    bytes[5] !== 0x0a ||
+    bytes[6] !== 0x1a ||
+    bytes[7] !== 0x0a
+  ) {
+    return 0;
+  }
+
+  let declaredFrameCount = 0;
+  let frameControlCount = 0;
+  for (let offset = 8; offset + 8 <= bytes.byteLength; ) {
+    const chunkLength =
+      (bytes[offset] << 24) |
+      (bytes[offset + 1] << 16) |
+      (bytes[offset + 2] << 8) |
+      bytes[offset + 3];
+    const chunkType = String.fromCharCode(
+      bytes[offset + 4],
+      bytes[offset + 5],
+      bytes[offset + 6],
+      bytes[offset + 7],
+    );
+    if (chunkType === "acTL" && chunkLength >= 4) {
+      declaredFrameCount =
+        (bytes[offset + 8] << 24) |
+        (bytes[offset + 9] << 16) |
+        (bytes[offset + 10] << 8) |
+        bytes[offset + 11];
+    } else if (chunkType === "fcTL") {
+      frameControlCount += 1;
+    }
+    offset += 12 + chunkLength;
+  }
+
+  return Math.max(declaredFrameCount, frameControlCount);
+};
+
+export const sniffAssetInfo = async (
+  blob: Blob,
+  fallbackExt: string,
+): Promise<SniffedAssetInfo> => {
+  const normalizedFallback = normalizeAssetExt(fallbackExt);
+
+  if (
+    normalizedFallback === "json" ||
+    blob.type.includes("json") ||
+    blob.type.includes("lottie")
+  ) {
+    return { detectedExt: "json", isAnimated: false, frameCount: 0 };
+  }
+
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    const frameCount = countPngFrames(bytes);
+    return {
+      detectedExt: "png",
+      isAnimated: frameCount > 1,
+      frameCount,
+    };
+  }
+
+  if (
+    bytes.length >= 6 &&
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38 &&
+    (bytes[4] === 0x37 || bytes[4] === 0x39) &&
+    bytes[5] === 0x61
+  ) {
+    const frameCount = countGifFrames(bytes);
+    return {
+      detectedExt: "gif",
+      isAnimated: frameCount > 1,
+      frameCount,
+    };
+  }
+
+  if (hasRiffWebpHeader(bytes)) {
+    const frameCount = countAnimatedWebpFrames(bytes);
+    return {
+      detectedExt: "webp",
+      isAnimated: frameCount > 1,
+      frameCount,
+    };
+  }
+
+  return {
+    detectedExt: normalizedFallback as AssetBinaryFormat,
+    isAnimated: false,
+    frameCount: 0,
+  };
+};
+
+const getImageDecoder = () => (globalThis as { ImageDecoder?: unknown }).ImageDecoder;
+
+const createFrameCanvas = (width: number, height: number) => {
+  if (typeof OffscreenCanvas !== "undefined") {
+    return new OffscreenCanvas(width, height);
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+};
+
+const encodeCanvasToPng = async (
+  canvas: OffscreenCanvas | HTMLCanvasElement,
+) => {
+  if ("convertToBlob" in canvas) {
+    return canvas.convertToBlob({ type: "image/png" });
+  }
+
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob);
+        return;
+      }
+      reject(new Error("Could not encode PNG output."));
+    }, "image/png");
+  });
+};
+
+const frameDurationToMs = (duration?: number | null) => {
+  if (!duration || duration <= 0) return 100;
+  return Math.max(20, Math.round(duration / 1000));
+};
+
+const buildGifFrame = (
+  rgba: Uint8ClampedArray,
+  hasTransparency: boolean,
+) => {
+  if (!hasTransparency) {
+    const palette = quantize(rgba, 256);
+    return {
+      palette,
+      index: applyPalette(rgba, palette),
+      transparent: false,
+    };
+  }
+
+  const palette = quantize(rgba, 255, {
+    format: "rgba4444",
+    oneBitAlpha: 127,
+    clearAlpha: true,
+    clearAlphaThreshold: 127,
+  }).filter((color: number[]) => color[3] !== 0);
+
+  const paletted = [[0, 0, 0, 0], ...palette];
+
+  return {
+    palette: paletted,
+    index: applyPalette(rgba, paletted, "rgba4444"),
+    transparent: true,
+  };
+};
+
+const hasTransparentPixels = (rgba: Uint8ClampedArray) => {
+  for (let index = 3; index < rgba.length; index += 4) {
+    if (rgba[index] < 250) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const drawDecodedFrame = async (
+  context: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D,
+  frame: CanvasImageSource,
+  width: number,
+  height: number,
+) => {
+  context.clearRect(0, 0, width, height);
+
+  try {
+    context.drawImage(frame, 0, 0, width, height);
+    return;
+  } catch (error) {
+    if (typeof createImageBitmap !== "function") {
+      throw error;
+    }
+
+    const bitmap = await createImageBitmap(frame as ImageBitmapSource);
+    try {
+      context.drawImage(bitmap, 0, 0, width, height);
+    } finally {
+      bitmap.close?.();
+    }
+  }
+};
+
+export const convertAnimatedImageToGif = async (
+  blob: Blob,
+  detectedExt: AssetBinaryFormat,
+  expectedFrameCount?: number,
+) => {
+  const ImageDecoderCtor = getImageDecoder() as
+    | {
+        new (options: { data: Uint8Array; type: string }): {
+          tracks?: {
+            selectedTrack?: {
+              frameCount?: number;
+              repetitionCount?: number;
+            };
+          };
+          decode(options: {
+            frameIndex: number;
+            completeFramesOnly?: boolean;
+          }): Promise<{
+            image: {
+              displayWidth: number;
+              displayHeight: number;
+              codedWidth: number;
+              codedHeight: number;
+              duration?: number | null;
+              close?: () => void;
+            };
+            complete: boolean;
+          }>;
+          close?: () => void;
+        };
+        isTypeSupported?: (type: string) => Promise<boolean>;
+      }
+    | undefined;
+
+  if (!ImageDecoderCtor) {
+    throw new Error("ImageDecoder is unavailable in this browser.");
+  }
+
+  const mimeType =
+    detectedExt === "webp"
+      ? "image/webp"
+      : detectedExt === "png"
+        ? "image/png"
+        : null;
+
+  if (!mimeType) {
+    throw new Error(`Cannot convert ${detectedExt} to GIF.`);
+  }
+
+  if (typeof ImageDecoderCtor.isTypeSupported === "function") {
+    const supported = await ImageDecoderCtor.isTypeSupported(mimeType);
+    if (!supported) {
+      throw new Error(`ImageDecoder does not support ${mimeType}.`);
+    }
+  }
+
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  const decoder = new ImageDecoderCtor({ data: bytes, type: mimeType });
+  const track = decoder.tracks?.selectedTrack;
+  const frameCount = Math.max(expectedFrameCount || 0, 1);
+
+  if (frameCount <= 1) {
+    decoder.close?.();
+    throw new Error(`Expected an animated ${detectedExt} image.`);
+  }
+
+  const firstDecode = await decoder.decode({
+    frameIndex: 0,
+    completeFramesOnly: true,
+  });
+  const firstFrame = firstDecode.image;
+  const width = firstFrame.displayWidth || firstFrame.codedWidth;
+  const height = firstFrame.displayHeight || firstFrame.codedHeight;
+  const canvas = createFrameCanvas(width, height);
+  const context = canvas.getContext("2d", {
+    willReadFrequently: true,
+  }) as OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null;
+
+  if (!context) {
+    firstFrame.close?.();
+    decoder.close?.();
+    throw new Error("Could not acquire a 2D canvas context for GIF conversion.");
+  }
+
+  const gif = GIFEncoder();
+  const repeat = typeof track?.repetitionCount === "number" ? track.repetitionCount : 0;
+
+  const writeFrame = async (
+    frame: typeof firstFrame,
+    frameIndex: number,
+  ) => {
+    await drawDecodedFrame(
+      context,
+      frame as unknown as CanvasImageSource,
+      width,
+      height,
+    );
+    const imageData = context.getImageData(0, 0, width, height);
+    const transparent = hasTransparentPixels(imageData.data);
+    const encodedFrame = buildGifFrame(imageData.data, transparent);
+    gif.writeFrame(encodedFrame.index, width, height, {
+      palette: encodedFrame.palette,
+      delay: frameDurationToMs(frame.duration),
+      repeat: frameIndex === 0 ? repeat : undefined,
+      transparent: encodedFrame.transparent,
+      transparentIndex: 0,
+    });
+  };
+
+  try {
+    await writeFrame(firstFrame, 0);
+  } finally {
+    firstFrame.close?.();
+  }
+
+  for (let frameIndex = 1; frameIndex < frameCount; frameIndex += 1) {
+    const decoded = await decoder.decode({
+      frameIndex,
+      completeFramesOnly: true,
+    });
+    try {
+      await writeFrame(decoded.image, frameIndex);
+    } finally {
+      decoded.image.close?.();
+    }
+  }
+
+  gif.finish();
+  decoder.close?.();
+  return new Blob([gif.bytes()], { type: "image/gif" });
+};
+
+export const convertStaticImageToPng = async (blob: Blob) => {
+  if (typeof createImageBitmap !== "function") {
+    throw new Error("createImageBitmap is unavailable in this browser.");
+  }
+
+  const bitmap = await createImageBitmap(blob);
+  try {
+    const canvas = createFrameCanvas(bitmap.width, bitmap.height);
+    const context = canvas.getContext("2d") as
+      | OffscreenCanvasRenderingContext2D
+      | CanvasRenderingContext2D
+      | null;
+
+    if (!context) {
+      throw new Error("Could not acquire a 2D canvas context for PNG conversion.");
+    }
+
+    context.clearRect(0, 0, bitmap.width, bitmap.height);
+    context.drawImage(bitmap, 0, 0, bitmap.width, bitmap.height);
+    return await encodeCanvasToPng(canvas);
+  } finally {
+    bitmap.close?.();
+  }
+};
+
+export const finalizeDownloadedAssetBlob = async (
+  type: ExportAssetType,
+  sourceBlob: Blob,
+  transportExt: string,
+): Promise<FinalizedAssetInfo> => {
+  const sniffed = await sniffAssetInfo(sourceBlob, transportExt);
+  let finalBlob = sourceBlob;
+  let finalExt = sniffed.detectedExt;
+  let isAnimated = sniffed.isAnimated;
+
+  if (
+    sniffed.isAnimated &&
+    sniffed.detectedExt !== "gif" &&
+    sniffed.detectedExt !== "json" &&
+    sniffed.detectedExt !== "unknown"
+  ) {
+    finalBlob = await convertAnimatedImageToGif(
+      sourceBlob,
+      sniffed.detectedExt,
+      sniffed.frameCount,
+    );
+    finalExt = "gif";
+    isAnimated = true;
+  } else if (
+    !sniffed.isAnimated &&
+    sniffed.detectedExt !== "png" &&
+    sniffed.detectedExt !== "json" &&
+    sniffed.detectedExt !== "unknown"
+  ) {
+    finalBlob = await convertStaticImageToPng(sourceBlob);
+    finalExt = "png";
+    isAnimated = false;
+  }
+
+  if (type === "sticker" && sniffed.detectedExt === "json") {
+    finalExt = "json";
+    isAnimated = false;
+  }
+
+  return {
+    detectedExt: sniffed.detectedExt,
+    finalExt,
+    isAnimated,
+    finalBlob,
+  };
+};
+
+export { normalizeAssetExt };

--- a/src/containers/emoji-export-button/emoji-export-button.tsx
+++ b/src/containers/emoji-export-button/emoji-export-button.tsx
@@ -8,8 +8,7 @@ import {
   FormControlLabel,
   ListItem,
   Stack,
-  ToggleButton,
-  ToggleButtonGroup,
+  TextField,
   Typography,
 } from "@mui/material";
 import { FixedSizeList, ListChildComponentProps } from "react-window";
@@ -17,18 +16,27 @@ import SmartToyIcon from "@mui/icons-material/SmartToy";
 import ConstructionIcon from "@mui/icons-material/Construction";
 import TaskAltIcon from "@mui/icons-material/TaskAlt";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import classNames from "classnames";
 import EnhancedDialogTitle from "../../common-components/enhanced-dialog/enhanced-dialog-title.tsx";
 import { useGuildSlice } from "../../features/guild/use-guild-slice.ts";
 import { useUserSlice } from "../../features/user/use-user-slice.ts";
 import DiscordService from "../../services/discord-service.ts";
 import { useAppSlice } from "../../features/app/use-app-slice.ts";
-import { getOsSafeString } from "../../utils.ts";
 import { nanoid } from "nanoid";
 import { DiscrubSetting } from "../../enum/discrub-setting.ts";
 import { AppSettings } from "../../features/app/app-types.ts";
 import "../purge-button/css/purge-status-header.css";
+import ArchiveWriter from "../../features/export/archive-writer.ts";
+import {
+  buildEmojiMetaFiles,
+  buildWebsiteAssetFileName,
+  type PostprocessAssetInput,
+} from "./emoji-export-postprocess.ts";
+import {
+  finalizeDownloadedAssetBlob,
+  normalizeAssetExt,
+  type AssetBinaryFormat,
+} from "./emoji-export-asset-format.ts";
 
 type EmojiExportButtonProps = {
   disabled?: boolean;
@@ -52,32 +60,55 @@ type ManifestItem = {
   key: string;
   name: string;
   ext: string;
+  transportExt: string;
+  detectedExt: string;
+  finalExt: string;
+  isAnimated: boolean;
   url: string;
   file: string;
   guildId: Snowflake;
   guildName: string;
 };
 
-type ExportAssetMode = "emoji" | "sticker" | "both";
-
 type EmojiAssetCandidate = {
   type: AssetType;
   id: Snowflake;
   key: string;
   name: string;
-  ext: string;
+  transportExt: string;
+  animatedHint: boolean;
   baseUrl: string;
   downloadUrl: string;
-  file: string;
   guildId: Snowflake;
   guildName: string;
 };
 
+type DownloadedAsset = {
+  candidate: EmojiAssetCandidate;
+  sourceBlob: Blob;
+  transportExt: string;
+  detectedExt: AssetBinaryFormat;
+  finalExt: string;
+  isAnimated: boolean;
+  finalBlob: Blob;
+  finalFile: string;
+};
+
+type ExportProgress = {
+  added: number;
+  downloaded: number;
+  failed: number;
+  processedGuilds: number;
+  totalGuilds: number;
+};
+
 type EmojiExportResumeState = {
-  version: 1;
+  version: 6;
   nextGuildId?: Snowflake;
+  completedGuildIds?: Snowflake[];
   seenKeys: string[];
   manifest: ManifestItem[];
+  generateMetaFiles: boolean;
   updatedAt: number;
 };
 
@@ -90,9 +121,17 @@ enum EmojiInstruction {
 
 const LOG_LIMIT = 1200;
 const EMOJI_EXPORT_RESUME_KEY = "discrub_emoji_export_resume_v1";
+const EMOJI_EXPORT_RESUME_VERSION = 6;
 const GUILD_FETCH_TIMEOUT_MS = 15000;
 const DOWNLOAD_TIMEOUT_MS = 12000;
-const EMOJI_DOWNLOAD_BATCH_SIZE = 8;
+const EMOJI_DOWNLOAD_BATCH_SIZE = 4;
+const MIN_WORKER_COUNT = 1;
+const MAX_WORKER_COUNT = 12;
+const DEFAULT_WORKER_COUNT = 3;
+const LOG_FLUSH_INTERVAL_MS = 80;
+const RESUME_SAVE_INTERVAL_MS = 2000;
+const EXPORT_FILE_PREFIX = "discord-emojis";
+const EXPORT_LOG_OPERATION = "emoji-export";
 
 const INVALID_FILE_CHARS = /[<>:"/\\|?*\x00-\x1F]/g;
 
@@ -108,6 +147,8 @@ const cleanAssetName = (value: string) =>
 
 const getStickerExt = (formatType?: number): string => {
   switch (formatType) {
+    case 1:
+      return "png";
     case 4:
       return "gif";
     case 3:
@@ -119,64 +160,31 @@ const getStickerExt = (formatType?: number): string => {
   }
 };
 
-const modeAllowsType = (mode: ExportAssetMode, type: AssetType) => {
-  if (mode === "both") return true;
-  return mode === type;
+const EMPTY_EXPORT_PROGRESS: ExportProgress = {
+  added: 0,
+  downloaded: 0,
+  failed: 0,
+  processedGuilds: 0,
+  totalGuilds: 0,
 };
 
-const stripQuery = (url: string) => {
-  try {
-    const parsed = new URL(url);
-    return `${parsed.origin}${parsed.pathname}`;
-  } catch {
-    return url.split("?")[0];
-  }
+const formatExportTimestamp = (date: Date = new Date()) => {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${pad(date.getHours())}${pad(date.getMinutes())}-${pad(
+    date.getDate(),
+  )}${pad(date.getMonth() + 1)}${date.getFullYear()}`;
 };
 
-const downloadBlob = (fileName: string, blob: Blob) => {
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = fileName;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  setTimeout(() => URL.revokeObjectURL(url), 1500);
+const clampWorkerCount = (value: number) =>
+  Math.min(MAX_WORKER_COUNT, Math.max(MIN_WORKER_COUNT, value));
+
+const parseWorkerCount = (value: string) => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? clampWorkerCount(parsed) : DEFAULT_WORKER_COUNT;
 };
 
-const downloadWithChromeApi = async (url: string, filename: string) => {
-  const downloads = globalThis.chrome?.downloads;
-  if (!downloads?.download) {
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = filename;
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-    return;
-  }
-
-  await new Promise<void>((resolve, reject) => {
-    downloads.download(
-      {
-        url,
-        filename,
-        saveAs: false,
-        conflictAction: "uniquify",
-      },
-      (downloadId) => {
-        const errorMessage = globalThis.chrome?.runtime?.lastError?.message;
-        if (errorMessage || typeof downloadId !== "number") {
-          reject(
-            new Error(errorMessage || `Download failed for ${filename}`),
-          );
-          return;
-        }
-        resolve();
-      },
-    );
-  });
-};
+const getErrorDetail = (error: unknown) =>
+  error instanceof Error && error.message ? error.message : "unexpected error";
 
 const withTimeout = async <T,>(
   promise: Promise<T>,
@@ -213,7 +221,6 @@ const normalizeManifestItem = (item: unknown): ManifestItem | null => {
     typeof source.id !== "string" ||
     typeof source.key !== "string" ||
     typeof source.name !== "string" ||
-    typeof source.ext !== "string" ||
     typeof source.url !== "string" ||
     typeof source.file !== "string"
   ) {
@@ -221,14 +228,47 @@ const normalizeManifestItem = (item: unknown): ManifestItem | null => {
   }
 
   const normalizedType: AssetType = type === "emoji" ? "emoji" : "sticker";
+  const finalExt = normalizeAssetExt(
+    typeof source.finalExt === "string"
+      ? source.finalExt
+      : typeof source.ext === "string"
+        ? source.ext
+        : "",
+  );
+  const transportExt = normalizeAssetExt(
+    typeof source.transportExt === "string"
+      ? source.transportExt
+      : finalExt,
+  );
+  const detectedExt = normalizeAssetExt(
+    typeof source.detectedExt === "string"
+      ? source.detectedExt
+      : finalExt,
+  );
+  const isAnimated =
+    source.isAnimated === true ||
+    (typeof source.finalExt === "string"
+      ? normalizeAssetExt(source.finalExt) === "gif"
+      : typeof source.ext === "string" &&
+        normalizeAssetExt(source.ext) === "gif");
+
   return {
     type: normalizedType,
     id: source.id,
     key: source.key,
     name: source.name,
-    ext: source.ext,
-    url: stripQuery(source.url),
-    file: source.file,
+    ext: finalExt,
+    transportExt,
+    detectedExt,
+    finalExt,
+    isAnimated,
+    url: source.url,
+    file: buildWebsiteAssetFileName(
+      normalizedType,
+      source.name,
+      source.id,
+      finalExt,
+    ),
     guildId: typeof source.guildId === "string" ? source.guildId : "",
     guildName: typeof source.guildName === "string" ? source.guildName : "",
   };
@@ -246,7 +286,7 @@ const loadResumeState = async (): Promise<EmojiExportResumeState | null> => {
 
   const data = raw as Partial<EmojiExportResumeState>;
   if (
-    data.version !== 1 ||
+    data.version !== EMOJI_EXPORT_RESUME_VERSION ||
     !Array.isArray(data.seenKeys) ||
     !Array.isArray(data.manifest)
   ) {
@@ -262,11 +302,17 @@ const loadResumeState = async (): Promise<EmojiExportResumeState | null> => {
   );
 
   return {
-    version: 1,
+    version: EMOJI_EXPORT_RESUME_VERSION,
     nextGuildId:
       typeof data.nextGuildId === "string" ? data.nextGuildId : undefined,
+    completedGuildIds: Array.isArray(data.completedGuildIds)
+      ? data.completedGuildIds.filter(
+          (id): id is Snowflake => typeof id === "string" && id.length > 0,
+        )
+      : [],
     seenKeys,
     manifest,
+    generateMetaFiles: data.generateMetaFiles === true,
     updatedAt:
       typeof data.updatedAt === "number" ? data.updatedAt : Date.now(),
   };
@@ -306,17 +352,30 @@ const EmojiExportButton = ({
   const [isExporting, setIsExporting] = useState(false);
   const [stopRequested, setStopRequested] = useState(false);
   const [logs, setLogs] = useState<LogEntry[]>([]);
-  const [downloadAssets, setDownloadAssets] = useState(true);
-  const [assetMode, setAssetMode] = useState<ExportAssetMode>("emoji");
+  const [exportProgress, setExportProgress] = useState<ExportProgress>(
+    EMPTY_EXPORT_PROGRESS,
+  );
+  const [generateMetaFiles, setGenerateMetaFiles] = useState(false);
+  const [includeStickers, setIncludeStickers] = useState(false);
   const [importedManifest, setImportedManifest] = useState<ManifestItem[]>([]);
+  const [workerCountInput, setWorkerCountInput] = useState(
+    String(DEFAULT_WORKER_COUNT),
+  );
 
   const abortRef = useRef(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const lastOpenSignalRef = useRef<number | undefined>(openSignal);
+  const queuedLogsRef = useRef<LogEntry[]>([]);
+  const allLogsRef = useRef<string[]>([]);
+  const logFlushTimerRef = useRef<number | null>(null);
 
   const sortedGuilds = useMemo(
     () => [...guilds].sort((a, b) => a.name.localeCompare(b.name)),
     [guilds],
+  );
+  const resolvedWorkerCount = useMemo(
+    () => parseWorkerCount(workerCountInput),
+    [workerCountInput],
   );
 
   useEffect(() => {
@@ -336,10 +395,56 @@ const EmojiExportButton = ({
     lastOpenSignalRef.current = openSignal;
   }, [openSignal]);
 
+  useEffect(() => {
+    return () => {
+      if (logFlushTimerRef.current !== null) {
+        window.clearTimeout(logFlushTimerRef.current);
+      }
+    };
+  }, []);
+
+  const flushLogs = () => {
+    if (!queuedLogsRef.current.length) {
+      logFlushTimerRef.current = null;
+      return;
+    }
+
+    const pendingLogs = [...queuedLogsRef.current].reverse();
+    queuedLogsRef.current = [];
+    logFlushTimerRef.current = null;
+
+    setLogs((prevState) => [...pendingLogs, ...prevState].slice(0, LOG_LIMIT));
+  };
+
   const appendLog = (text: string, level: LogLevel = "info") => {
-    setLogs((prevState) =>
-      [{ id: nanoid(), text, level }, ...prevState].slice(0, LOG_LIMIT),
-    );
+    queuedLogsRef.current.push({ id: nanoid(), text, level });
+    allLogsRef.current.push(text);
+
+    if (logFlushTimerRef.current !== null) {
+      return;
+    }
+
+    logFlushTimerRef.current = window.setTimeout(flushLogs, LOG_FLUSH_INTERVAL_MS);
+  };
+
+  const resetDialogState = () => {
+    if (logFlushTimerRef.current !== null) {
+      window.clearTimeout(logFlushTimerRef.current);
+      logFlushTimerRef.current = null;
+    }
+
+    queuedLogsRef.current = [];
+    allLogsRef.current = [];
+    abortRef.current = false;
+
+    setInstruction(EmojiInstruction.AWAITING_INSTRUCTION);
+    setLogs([]);
+    setExportProgress(EMPTY_EXPORT_PROGRESS);
+    setGenerateMetaFiles(false);
+    setIncludeStickers(false);
+    setImportedManifest([]);
+    setWorkerCountInput(String(DEFAULT_WORKER_COUNT));
+    setStopRequested(false);
   };
 
   const getLogRow = ({ index, style }: ListChildComponentProps) => {
@@ -353,7 +458,16 @@ const EmojiExportButton = ({
 
     return (
       <ListItem style={style} key={row.id} dense divider>
-        <Typography variant="body2" sx={{ color, fontFamily: "monospace" }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color,
+            fontFamily: "monospace",
+            fontSize: "0.73rem",
+            lineHeight: 1.25,
+            wordBreak: "break-word",
+          }}
+        >
           {row.text}
         </Typography>
       </ListItem>
@@ -371,17 +485,7 @@ const EmojiExportButton = ({
       return;
     }
     setDialogOpen(false);
-  };
-
-  const handleShowDownloadSetup = () => {
-    window.alert(
-      [
-        "Configure Chrome downloads before export:",
-        "1) Open a new tab manually: chrome://settings/downloads",
-        "2) Set your preferred Download location",
-        "3) Disable 'Ask where to save each file before downloading'",
-      ].join("\n"),
-    );
+    resetDialogState();
   };
 
   const handleImportManifest = () => {
@@ -409,7 +513,11 @@ const EmojiExportButton = ({
 
       const normalized = parsed
         .map((item) => normalizeManifestItem(item))
-        .filter((item): item is ManifestItem => item !== null);
+        .filter((item): item is ManifestItem => {
+          if (item === null) return false;
+          if (item.type === "emoji") return true;
+          return includeStickers && item.type === "sticker";
+        });
 
       setImportedManifest(normalized);
       appendLog(`Imported ${normalized.length} manifest item(s).`, "ok");
@@ -434,28 +542,31 @@ const EmojiExportButton = ({
   const buildDownloadUrl = (
     type: AssetType,
     id: Snowflake,
-    ext: string,
+    transportExt: string,
+    animatedHint: boolean = false,
   ): { baseUrl: string; downloadUrl: string } => {
     const folder = type === "emoji" ? "emojis" : "stickers";
-    const baseUrl = `https://cdn.discordapp.com/${folder}/${id}.${ext}`;
+    const origin =
+      type === "sticker"
+        ? "https://media.discordapp.net"
+        : "https://cdn.discordapp.com";
+    const baseUrl = `${origin}/${folder}/${id}.${transportExt}`;
 
-    if (ext === "json") {
+    if (transportExt === "json") {
       return { baseUrl, downloadUrl: baseUrl };
     }
 
     const url = new URL(baseUrl);
     url.searchParams.set("quality", "lossless");
     url.searchParams.set("size", type === "sticker" ? "320" : "160");
+    if (type === "emoji" && animatedHint && transportExt === "webp") {
+      url.searchParams.set("animated", "true");
+    }
     return { baseUrl, downloadUrl: url.toString() };
   };
 
   const handleExportEmojis = async () => {
     if (!token || isExporting || !sortedGuilds.length) return;
-
-    const allowed = window.confirm(
-      "Export Emojis will scan all servers and may trigger many downloads. Make sure Chrome download folder settings are ready. Continue?",
-    );
-    if (!allowed) return;
 
     const noDelaySettings: AppSettings = {
       ...settings,
@@ -466,31 +577,47 @@ const EmojiExportButton = ({
     const discordService = new DiscordService(noDelaySettings);
     let startIndex = 0;
     let resumeLoaded = false;
+    let resumeSettingMismatch = false;
     let resumeRestoreCount = 0;
+    const completedGuildIds = new Set<Snowflake>();
 
     const importedMap = new Map<string, ManifestItem>();
     for (const item of importedManifest) {
-      if (!modeAllowsType(assetMode, item.type)) continue;
+      if (item.type !== "emoji" && !(includeStickers && item.type === "sticker")) {
+        continue;
+      }
       importedMap.set(item.key, item);
     }
 
     try {
       const resumeState = await loadResumeState();
       if (resumeState) {
-        resumeLoaded = true;
-        resumeRestoreCount = resumeState.manifest.filter((item) =>
-          modeAllowsType(assetMode, item.type),
-        ).length;
-        for (const item of resumeState.manifest) {
-          if (!modeAllowsType(assetMode, item.type)) continue;
-          importedMap.set(item.key, item);
-        }
-        if (resumeState.nextGuildId) {
-          const resumeIndex = sortedGuilds.findIndex(
-            (guild) => guild.id === resumeState.nextGuildId,
-          );
-          if (resumeIndex >= 0) {
-            startIndex = resumeIndex;
+        if (resumeState.generateMetaFiles !== generateMetaFiles) {
+          resumeSettingMismatch = true;
+        } else {
+          resumeLoaded = true;
+          resumeRestoreCount = resumeState.manifest.filter((item) =>
+            item.type === "emoji" || (includeStickers && item.type === "sticker"),
+          ).length;
+          for (const completedGuildId of resumeState.completedGuildIds || []) {
+            completedGuildIds.add(completedGuildId);
+          }
+          for (const item of resumeState.manifest) {
+            if (
+              item.type !== "emoji" &&
+              !(includeStickers && item.type === "sticker")
+            ) {
+              continue;
+            }
+            importedMap.set(item.key, item);
+          }
+          if (resumeState.nextGuildId) {
+            const resumeIndex = sortedGuilds.findIndex(
+              (guild) => guild.id === resumeState.nextGuildId,
+            );
+            if (resumeIndex >= 0) {
+              startIndex = resumeIndex;
+            }
           }
         }
       }
@@ -501,252 +628,535 @@ const EmojiExportButton = ({
 
     const manifest: ManifestItem[] = Array.from(importedMap.values());
     const seenKeys = new Set<string>(manifest.map((item) => item.key));
+    const guildsToProcess = sortedGuilds.filter(
+      (guild, index) => index >= startIndex && !completedGuildIds.has(guild.id),
+    );
+    const shouldGenerateMetaFiles = generateMetaFiles;
+    const exportTimestamp = formatExportTimestamp();
+    const archiveName = `${EXPORT_FILE_PREFIX}-${exportTimestamp}.zip`;
+    const archiveWriter = new ArchiveWriter(archiveName);
+    let archiveFinalized = false;
+    let archiveQueue = Promise.resolve();
+    let resumeSaveQueue = Promise.resolve();
+    let latestResumeNextGuildId: Snowflake | undefined = guildsToProcess[0]?.id;
+    let resumeDirty = false;
+    let resumeIntervalId: number | null = null;
+    let processedGuildCount = 0;
+    const downloadedAssets = new Map<string, DownloadedAsset>();
+    const assetArchiveDir = "resources/emoji/assets";
+    const metaArchiveDir = "resources/emoji-meta";
+    const archiveLogName = `logs-${EXPORT_LOG_OPERATION}-${exportTimestamp}.txt`;
+    const getFinalFileName = (
+      type: AssetType,
+      name: string,
+      id: Snowflake,
+      finalExt: string,
+    ) =>
+      buildWebsiteAssetFileName(type, name, id, finalExt);
+    const resolveDownloadedAsset = async (
+      candidate: EmojiAssetCandidate,
+      sourceBlob: Blob,
+    ): Promise<DownloadedAsset> => {
+      const finalized = await finalizeDownloadedAssetBlob(
+        candidate.type,
+        sourceBlob,
+        candidate.transportExt,
+      );
+
+      const finalFile = getFinalFileName(
+        candidate.type,
+        candidate.name,
+        candidate.id,
+        finalized.finalExt,
+      );
+
+      return {
+        candidate,
+        sourceBlob,
+        transportExt: candidate.transportExt,
+        detectedExt: finalized.detectedExt,
+        finalExt: finalized.finalExt,
+        isAnimated: finalized.isAnimated,
+        finalBlob: finalized.finalBlob,
+        finalFile,
+      };
+    };
+    const syncProgress = () => {
+      setExportProgress({
+        added: newEntries,
+        downloaded: downloadOk,
+        failed: downloadFail,
+        processedGuilds: processedGuildCount,
+        totalGuilds: guildsToProcess.length,
+      });
+    };
 
     abortRef.current = false;
+    queuedLogsRef.current = [];
+    allLogsRef.current = [];
+    if (logFlushTimerRef.current !== null) {
+      window.clearTimeout(logFlushTimerRef.current);
+      logFlushTimerRef.current = null;
+    }
     setLogs([]);
+    setExportProgress({
+      ...EMPTY_EXPORT_PROGRESS,
+      totalGuilds: guildsToProcess.length,
+    });
     setIsExporting(true);
     setStopRequested(false);
     setInstruction(EmojiInstruction.EXPORTING);
 
-    appendLog(`Starting emoji export for ${sortedGuilds.length} guild(s).`);
+    appendLog(`Starting emoji export for ${guildsToProcess.length} guild(s).`);
+    appendLog(`ZIP archive enabled: ${archiveName}.`);
     appendLog(
-      downloadAssets
-        ? "Asset download enabled (files + manifest)."
-        : "Asset download disabled (manifest only).",
-    );
-    appendLog(
-      assetMode === "both"
+      includeStickers
         ? "Asset mode: emojis + stickers."
-        : assetMode === "emoji"
-          ? "Asset mode: emojis only."
-          : "Asset mode: stickers only.",
+        : "Asset mode: emojis only.",
     );
+    appendLog(
+      shouldGenerateMetaFiles
+        ? "Meta generation enabled. Website rename always on."
+        : "Meta generation disabled. Website rename still on.",
+    );
+    if (resumeSettingMismatch) {
+      appendLog(
+        "Resume ignored because Generate Meta Files setting changed.",
+        "error",
+      );
+    }
     if (resumeLoaded) {
       appendLog(
-        `Resume loaded. Restored ${resumeRestoreCount} item(s). Starting from guild ${startIndex + 1}/${sortedGuilds.length}.`,
+        `Resume loaded. Restored ${resumeRestoreCount} item(s).`,
         "ok",
       );
     }
+    appendLog(
+      `Guild worker pool enabled: ${Math.min(
+        resolvedWorkerCount,
+        guildsToProcess.length,
+      )} worker(s).`,
+    );
 
     let downloadOk = 0;
     let downloadFail = 0;
     let newEntries = 0;
 
-    const persistResume = async (nextIndex: number) => {
-      const nextGuildId =
-        nextIndex < sortedGuilds.length ? sortedGuilds[nextIndex].id : undefined;
+    const enqueueArchiveWrite = <T,>(task: () => Promise<T>) => {
+      const nextTask = archiveQueue.then(task, task);
+      archiveQueue = nextTask.then(
+        () => undefined,
+        () => undefined,
+      );
+      return nextTask;
+    };
 
-      await saveResumeState({
-        version: 1,
-        nextGuildId,
-        seenKeys: Array.from(seenKeys),
-        manifest,
-        updatedAt: Date.now(),
-      });
+    const yieldToUi = () =>
+      new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+
+    const persistResume = async (nextGuildId?: Snowflake) => {
+      latestResumeNextGuildId = nextGuildId;
+      resumeDirty = true;
+    };
+
+    const flushResumeState = async (force: boolean = false) => {
+      if (!resumeDirty && !force) {
+        return;
+      }
+
+      const nextGuildId = latestResumeNextGuildId;
+      resumeDirty = false;
+
+      resumeSaveQueue = resumeSaveQueue
+        .then(() =>
+          saveResumeState({
+            version: EMOJI_EXPORT_RESUME_VERSION,
+            nextGuildId,
+            completedGuildIds: Array.from(completedGuildIds),
+            seenKeys: Array.from(seenKeys),
+            manifest,
+            generateMetaFiles,
+            updatedAt: Date.now(),
+          }),
+        )
+        .catch((error) => {
+          console.error(error);
+          appendLog("Resume state save failed for this checkpoint.", "error");
+        });
+
+      await resumeSaveQueue;
+    };
+
+    const markGuildProcessed = () => {
+      processedGuildCount += 1;
+      syncProgress();
+      if (
+        processedGuildCount === guildsToProcess.length ||
+        processedGuildCount % 10 === 0
+      ) {
+        appendLog(
+          `[OK] Progress: ${processedGuildCount}/${guildsToProcess.length} guilds processed, ${newEntries} new asset(s).`,
+          "ok",
+        );
+      }
     };
 
     try {
-      await persistResume(startIndex);
+      await persistResume(guildsToProcess[0]?.id);
+      await flushResumeState(true);
+      resumeIntervalId = window.setInterval(() => {
+        void flushResumeState();
+      }, RESUME_SAVE_INTERVAL_MS);
+      let cursor = 0;
+      const workerCount = Math.min(
+        resolvedWorkerCount,
+        guildsToProcess.length,
+      );
 
-      for (let index = startIndex; index < sortedGuilds.length; index++) {
-        if (abortRef.current) break;
+      const workerTasks = Array.from({ length: workerCount }, () =>
+        (async () => {
+          while (!abortRef.current) {
+            const index = cursor;
+            cursor += 1;
+            if (index >= guildsToProcess.length) {
+              break;
+            }
 
-        const guild = sortedGuilds[index];
-        appendLog(
-          `Scanning guild ${index + 1}/${sortedGuilds.length}: ${guild.name}`,
-        );
+            const guild = guildsToProcess[index];
+            let guildResponse: DiscordApiResponse<{
+              name: string;
+              emojis?: {
+                id: Snowflake | Maybe;
+                name: string | Maybe;
+                animated?: boolean;
+              }[];
+              stickers?: { id: Snowflake; name: string; format_type?: number }[];
+            }>;
+            try {
+              guildResponse = await withTimeout(
+                discordService.fetchGuildAssetData(token, guild.id),
+                GUILD_FETCH_TIMEOUT_MS,
+                "Guild asset request timed out.",
+              );
+            } catch (error) {
+              console.error(error);
+              appendLog(`[ERR] ${guild.name} -> guild request timeout`, "error");
+              completedGuildIds.add(guild.id);
+              markGuildProcessed();
+              await persistResume(guildsToProcess[cursor]?.id);
+              continue;
+            }
 
-        let guildResponse: DiscordApiResponse<{
-          name: string;
-          emojis?: { id: Snowflake | Maybe; name: string | Maybe; animated?: boolean }[];
-          stickers?: { id: Snowflake; name: string; format_type?: number }[];
-        }>;
-        try {
-          guildResponse = await withTimeout(
-            discordService.fetchGuildAssetData(token, guild.id),
-            GUILD_FETCH_TIMEOUT_MS,
-            "Guild asset request timed out.",
-          );
-        } catch (error) {
-          console.error(error);
-          appendLog(`[ERR] ${guild.name} -> guild request timeout`, "error");
-          continue;
-        }
+            if (!guildResponse.success || !guildResponse.data) {
+              const reason =
+                guildResponse.status === 403
+                  ? "no permission"
+                  : "unable to fetch guild assets";
+              appendLog(`[ERR] ${guild.name} -> ${reason}`, "error");
+              completedGuildIds.add(guild.id);
+              markGuildProcessed();
+              await persistResume(guildsToProcess[cursor]?.id);
+              continue;
+            }
 
-        if (!guildResponse.success || !guildResponse.data) {
-          const reason =
-            guildResponse.status === 403
-              ? "no permission"
-              : "unable to fetch guild assets";
-          appendLog(`[ERR] ${guild.name} -> ${reason}`, "error");
-          continue;
-        }
+            const guildName = guildResponse.data.name || guild.name;
+            const emojis = guildResponse.data.emojis || [];
+            const stickers = guildResponse.data.stickers || [];
 
-        const guildName = guildResponse.data.name || guild.name;
-        const emojis = guildResponse.data.emojis || [];
-        const stickers = guildResponse.data.stickers || [];
+            let guildAdded = 0;
+            const candidates: EmojiAssetCandidate[] = [];
 
-        let guildAdded = 0;
-        const candidates: EmojiAssetCandidate[] = [];
+            for (const emoji of emojis) {
+              if (abortRef.current) break;
+              if (!emoji.id) continue;
 
-        if (assetMode !== "sticker") {
-          for (const emoji of emojis) {
-            if (abortRef.current) break;
-            if (!emoji.id) continue;
+              const type: AssetType = "emoji";
+              const id = emoji.id;
+              const transportExt = emoji.animated ? "webp" : "png";
+              const key = `${type}:${id}`;
+              if (seenKeys.has(key)) continue;
 
-            const type: AssetType = "emoji";
-            const id = emoji.id;
-            const ext = emoji.animated ? "gif" : "webp";
-            const key = `${type}:${id}`;
-            if (seenKeys.has(key)) continue;
+              const name = cleanAssetName(emoji.name || `${type}_${id}`);
+              const { baseUrl, downloadUrl } = buildDownloadUrl(
+                type,
+                id,
+                transportExt,
+                emoji.animated === true,
+              );
+              candidates.push({
+                type: "emoji",
+                id,
+                key,
+                name,
+                transportExt,
+                animatedHint: emoji.animated === true,
+                baseUrl,
+                downloadUrl,
+                guildId: guild.id,
+                guildName,
+              });
+            }
 
-            const name = cleanAssetName(emoji.name || `${type}_${id}`);
-            const file = `${type}_${name}_${id}.${ext}`;
-            const { baseUrl, downloadUrl } = buildDownloadUrl(type, id, ext);
-            candidates.push({
-              type: "emoji",
-              id,
-              key,
-              name,
-              ext,
-              baseUrl,
-              downloadUrl,
-              file,
-              guildId: guild.id,
-              guildName,
-            });
-          }
-        }
+            if (includeStickers) {
+              for (const sticker of stickers) {
+                if (abortRef.current) break;
+                if (!sticker.id) continue;
 
-        if (assetMode !== "emoji") {
-          for (const sticker of stickers) {
-            if (abortRef.current) break;
-            if (!sticker.id) continue;
+                const type: AssetType = "sticker";
+                const id = sticker.id;
+                const transportExt = getStickerExt(sticker.format_type);
+                const key = `${type}:${id}`;
+                if (seenKeys.has(key)) continue;
 
-            const type: AssetType = "sticker";
-            const id = sticker.id;
-            const ext = getStickerExt(sticker.format_type);
-            const key = `${type}:${id}`;
-            if (seenKeys.has(key)) continue;
-
-            const name = cleanAssetName(sticker.name || `${type}_${id}`);
-            const file = `${type}_${name}_${id}.${ext}`;
-            const { baseUrl, downloadUrl } = buildDownloadUrl(type, id, ext);
-            candidates.push({
-              type: "sticker",
-              id,
-              key,
-              name,
-              ext,
-              baseUrl,
-              downloadUrl,
-              file,
-              guildId: guild.id,
-              guildName,
-            });
-          }
-        }
-
-        if (!downloadAssets) {
-          for (const candidate of candidates) {
-            seenKeys.add(candidate.key);
-            manifest.push({
-              type: candidate.type,
-              id: candidate.id,
-              key: candidate.key,
-              name: candidate.name,
-              ext: candidate.ext,
-              url: candidate.baseUrl,
-              file: candidate.file,
-              guildId: candidate.guildId,
-              guildName: candidate.guildName,
-            });
-            guildAdded += 1;
-            newEntries += 1;
-          }
-        } else {
-          for (
-            let start = 0;
-            start < candidates.length && !abortRef.current;
-            start += EMOJI_DOWNLOAD_BATCH_SIZE
-          ) {
-            const batch = candidates.slice(start, start + EMOJI_DOWNLOAD_BATCH_SIZE);
-            const batchResults = await Promise.all(
-              batch.map(async (candidate) => {
-                try {
-                  await withTimeout(
-                    downloadWithChromeApi(
-                      candidate.downloadUrl,
-                      `discrub-assets/${candidate.file}`,
-                    ),
-                    DOWNLOAD_TIMEOUT_MS,
-                    "Asset download timed out.",
-                  );
-                  return { ok: true as const, candidate };
-                } catch (error) {
-                  return { ok: false as const, candidate, error };
-                }
-              }),
-            );
-
-            for (const result of batchResults) {
-              if (result.ok) {
-                const candidate = result.candidate;
-                seenKeys.add(candidate.key);
-                manifest.push({
-                  type: candidate.type,
-                  id: candidate.id,
-                  key: candidate.key,
-                  name: candidate.name,
-                  ext: candidate.ext,
-                  url: candidate.baseUrl,
-                  file: candidate.file,
-                  guildId: candidate.guildId,
-                  guildName: candidate.guildName,
+                const name = cleanAssetName(sticker.name || `${type}_${id}`);
+                const { baseUrl, downloadUrl } = buildDownloadUrl(
+                  type,
+                  id,
+                  transportExt,
+                );
+                candidates.push({
+                  type: "sticker",
+                  id,
+                  key,
+                  name,
+                  transportExt,
+                  animatedHint: transportExt === "gif",
+                  baseUrl,
+                  downloadUrl,
+                  guildId: guild.id,
+                  guildName,
                 });
-                guildAdded += 1;
-                newEntries += 1;
-                downloadOk += 1;
-              } else {
-                console.error(result.error);
-                appendLog(`[ERR] Download failed: ${result.candidate.file}`, "error");
-                downloadFail += 1;
               }
             }
-          }
-        }
 
-        appendLog(`[OK] ${guild.name} -> added ${guildAdded} new asset(s).`, "ok");
-        try {
-          await persistResume(index + 1);
-        } catch (error) {
-          console.error(error);
-          appendLog("Resume state save failed for this checkpoint.", "error");
+            for (
+              let start = 0;
+              start < candidates.length && !abortRef.current;
+              start += EMOJI_DOWNLOAD_BATCH_SIZE
+            ) {
+              const batch = candidates.slice(
+                start,
+                start + EMOJI_DOWNLOAD_BATCH_SIZE,
+              );
+              const batchResults = await Promise.all(
+                batch.map(async (candidate) => {
+                  try {
+                    const response = await withTimeout(
+                      discordService.downloadFile(candidate.downloadUrl),
+                      DOWNLOAD_TIMEOUT_MS,
+                      "Asset download timed out.",
+                    );
+                    if (!response.success || !response.data) {
+                      return {
+                        ok: false as const,
+                        candidate,
+                        status: response.status,
+                        error: response.error,
+                      };
+                    }
+                    return { ok: true as const, candidate, data: response.data };
+                  } catch (error) {
+                    return {
+                      ok: false as const,
+                      candidate,
+                      status: undefined,
+                      error,
+                    };
+                  }
+                }),
+              );
+
+              for (const result of batchResults) {
+                if (result.ok) {
+                  try {
+                    const downloadedAsset = await resolveDownloadedAsset(
+                      result.candidate,
+                      result.data,
+                    );
+                    if (
+                      downloadedAsset.finalExt !== downloadedAsset.transportExt ||
+                      downloadedAsset.detectedExt !== downloadedAsset.transportExt
+                    ) {
+                      appendLog(
+                        `[OK] Format resolved: ${result.candidate.type}_${result.candidate.name}_${result.candidate.id}.${downloadedAsset.transportExt} -> ${downloadedAsset.finalFile}`,
+                        "ok",
+                      );
+                    }
+                    await enqueueArchiveWrite(async () => {
+                      await archiveWriter.addBlob(
+                        downloadedAsset.finalBlob,
+                        `${assetArchiveDir}/${downloadedAsset.finalFile}`,
+                      );
+                    });
+                    downloadedAssets.set(downloadedAsset.candidate.key, downloadedAsset);
+                    seenKeys.add(downloadedAsset.candidate.key);
+                    manifest.push({
+                      type: downloadedAsset.candidate.type,
+                      id: downloadedAsset.candidate.id,
+                      key: downloadedAsset.candidate.key,
+                      name: downloadedAsset.candidate.name,
+                      ext: downloadedAsset.finalExt,
+                      transportExt: downloadedAsset.transportExt,
+                      detectedExt: downloadedAsset.detectedExt,
+                      finalExt: downloadedAsset.finalExt,
+                      isAnimated: downloadedAsset.isAnimated,
+                      url: downloadedAsset.candidate.downloadUrl,
+                      file: downloadedAsset.finalFile,
+                      guildId: downloadedAsset.candidate.guildId,
+                      guildName: downloadedAsset.candidate.guildName,
+                    });
+                    guildAdded += 1;
+                    newEntries += 1;
+                    downloadOk += 1;
+                  } catch (error) {
+                    console.error(error);
+                    appendLog(
+                      `[ERR] Format processing failed: ${result.candidate.type}_${result.candidate.name}_${result.candidate.id}.${result.candidate.transportExt} (${getErrorDetail(
+                        error,
+                      )})`,
+                      "error",
+                    );
+                    downloadFail += 1;
+                  }
+                } else {
+                  console.error(result.error);
+                  const detail =
+                    typeof result.status === "number" && result.status > 0
+                      ? `HTTP ${result.status}`
+                      : result.error instanceof Error && result.error.message
+                        ? result.error.message
+                        : "request failed";
+                  appendLog(
+                    `[ERR] Download failed: ${result.candidate.type}_${result.candidate.name}_${result.candidate.id}.${result.candidate.transportExt} (${detail})`,
+                    "error",
+                  );
+                  downloadFail += 1;
+                }
+              }
+
+              syncProgress();
+              await yieldToUi();
+            }
+
+            appendLog(
+              `[OK] ${guild.name} -> added ${guildAdded} new asset(s).`,
+              "ok",
+            );
+            completedGuildIds.add(guild.id);
+            markGuildProcessed();
+            try {
+              await persistResume(guildsToProcess[cursor]?.id);
+            } catch (error) {
+              console.error(error);
+            }
+          }
+        })(),
+      );
+
+      await Promise.all(workerTasks);
+
+      if (!abortRef.current) {
+        const missingGuildCount = guildsToProcess.filter(
+          (guild) => !completedGuildIds.has(guild.id),
+        ).length;
+        if (missingGuildCount > 0) {
+          appendLog(
+            `[ERR] Verification failed: ${missingGuildCount} guild(s) not processed.`,
+            "error",
+          );
+        } else {
+          appendLog("[OK] Verification passed: all scheduled guilds processed.", "ok");
         }
       }
 
       if (abortRef.current) {
         appendLog("Export stopped. Progress saved for resume.", "error");
-      } else {
-        const manifestBlob = new Blob([JSON.stringify(manifest, null, 2)], {
-          type: "application/json",
+        await flushResumeState(true);
+        await enqueueArchiveWrite(async () => {
+          await archiveWriter.addText(
+            JSON.stringify(manifest, null, 2),
+            shouldGenerateMetaFiles
+              ? `${metaArchiveDir}/${EXPORT_FILE_PREFIX}-manifest-partial.json`
+              : `${EXPORT_FILE_PREFIX}-manifest-partial.json`,
+          );
+          await archiveWriter.addText(
+            `${allLogsRef.current.join("\n")}\n`,
+            archiveLogName,
+          );
         });
-        const manifestName = `discord-assets-manifest-${getOsSafeString(
-          new Date().toISOString().replace(/:/g, "-"),
-        )}.json`;
-        downloadBlob(manifestName, manifestBlob);
-
+        await archiveQueue;
+        await archiveWriter.close();
+        archiveFinalized = true;
         appendLog(
-          `Manifest downloaded (${manifest.length} total, ${newEntries} new).`,
+          `Partial archive downloaded (${manifest.length} total, ${newEntries} new).`,
+          "ok",
+        );
+      } else {
+        await flushResumeState(true);
+        await enqueueArchiveWrite(async () => {
+          if (shouldGenerateMetaFiles) {
+            const metaFiles = await buildEmojiMetaFiles(
+              manifest,
+              Array.from(downloadedAssets.values()).map((asset) => asset.finalFile),
+              Array.from(downloadedAssets.values()).map(
+                ({ candidate, finalExt, transportExt, isAnimated }): PostprocessAssetInput => ({
+                  type: candidate.type,
+                  id: candidate.id,
+                  name: candidate.name,
+                  ext: finalExt,
+                  originalFile: `${candidate.type}_${candidate.name}_${candidate.id}.${transportExt}`,
+                  isAnimated,
+                }),
+              ),
+            );
+
+            await archiveWriter.addText(
+              metaFiles.manifestJson,
+              `${metaArchiveDir}/${EXPORT_FILE_PREFIX}-manifest.json`,
+            );
+            await archiveWriter.addText(
+              metaFiles.manifestJs,
+              `${metaArchiveDir}/${EXPORT_FILE_PREFIX}-manifest.js`,
+            );
+            await archiveWriter.addText(
+              metaFiles.existingFilesJs,
+              `${metaArchiveDir}/${EXPORT_FILE_PREFIX}-existing-files.js`,
+            );
+            await archiveWriter.addText(
+              metaFiles.animatedWebpJs,
+              `${metaArchiveDir}/${EXPORT_FILE_PREFIX}-animated-webp.js`,
+            );
+            await archiveWriter.addText(
+              metaFiles.manifestJson,
+              `${EXPORT_FILE_PREFIX}-manifest-${manifest.length}-${exportTimestamp}.json`,
+            );
+          } else {
+            await archiveWriter.addText(
+              JSON.stringify(manifest, null, 2),
+              `${EXPORT_FILE_PREFIX}-manifest.json`,
+            );
+          }
+          await archiveWriter.addText(
+            `${allLogsRef.current.join("\n")}\n`,
+            archiveLogName,
+          );
+        });
+        await archiveQueue;
+        await archiveWriter.close();
+        archiveFinalized = true;
+        appendLog(
+          `Archive downloaded (${manifest.length} total, ${newEntries} new).`,
           "ok",
         );
 
-        if (downloadAssets) {
-          appendLog(
-            `Asset downloads complete. Success: ${downloadOk}, Failed: ${downloadFail}.`,
-            downloadFail ? "error" : "ok",
-          );
+        if (shouldGenerateMetaFiles) {
+          appendLog("Website rename applied to exported asset filenames.", "ok");
+          appendLog("Meta files generated and added to archive.", "ok");
         }
+        appendLog(
+          `Asset downloads complete. Success: ${downloadOk}, Failed: ${downloadFail}.`,
+          downloadFail ? "error" : "ok",
+        );
 
         try {
           await clearResumeState();
@@ -763,9 +1173,26 @@ const EmojiExportButton = ({
       );
     } catch (error) {
       console.error(error);
-      appendLog("Emoji export failed due to unexpected error.", "error");
+      appendLog(
+        `Emoji export failed due to unexpected error: ${getErrorDetail(error)}.`,
+        "error",
+      );
       setInstruction(EmojiInstruction.OPERATION_FAILED);
     } finally {
+      if (resumeIntervalId !== null) {
+        window.clearInterval(resumeIntervalId);
+      }
+      await resumeSaveQueue;
+      if (!archiveFinalized) {
+        try {
+          await archiveQueue;
+          await archiveWriter.close();
+        } catch (error) {
+          console.error(error);
+        }
+      }
+      flushLogs();
+      syncProgress();
       setIsExporting(false);
       setStopRequested(false);
       abortRef.current = false;
@@ -799,7 +1226,30 @@ const EmojiExportButton = ({
 
       <Dialog
         hideBackdrop
-        PaperProps={{ sx: { minWidth: "680px", minHeight: "540px" } }}
+        sx={{
+          zIndex: 2600,
+          "& .MuiDialog-container": {
+            alignItems: "flex-start",
+            justifyContent: "center",
+            pt: 1,
+            pb: 1,
+            overflow: "visible",
+          },
+        }}
+        PaperProps={{
+          sx: {
+            width: "min(640px, calc(100vw - 24px))",
+            minWidth: "min(640px, calc(100vw - 24px))",
+            height: "min(620px, calc(100vh - 16px))",
+            minHeight: "min(620px, calc(100vh - 16px))",
+            maxHeight: "min(620px, calc(100vh - 16px))",
+            m: 0,
+            overflow: "hidden",
+            zIndex: 2601,
+            display: "flex",
+            flexDirection: "column",
+          },
+        }}
         open={dialogOpen}
       >
         <EnhancedDialogTitle title="Export Emojis" onClose={handleClose} />
@@ -808,143 +1258,231 @@ const EmojiExportButton = ({
             display: "flex",
             flexDirection: "column",
             justifyContent: "flex-start",
-            gap: 1,
-            alignItems: "center",
+            alignItems: "stretch",
+            height: "100%",
+            minHeight: 0,
+            overflowY: "hidden",
+            overflowX: "hidden",
+            pb: 1.5,
           }}
         >
           <Box
             sx={{
               display: "flex",
-              flexDirection: "row",
-              justifyContent: "center",
+              flexDirection: "column",
+              gap: 0.75,
               alignItems: "center",
-              gap: 0.5,
+              flex: 1,
+              minHeight: 0,
+              overflowY: "auto",
+              overflowX: "hidden",
+              pr: 0.5,
             }}
           >
             <Box
-              className={classNames({
-                "operation-running": instruction === EmojiInstruction.EXPORTING,
-              })}
-            >
-              {getInstructionIcon()}
-            </Box>
-            <Typography variant="h6">{instruction}</Typography>
-          </Box>
-
-          <Stack
-            direction="row"
-            alignItems="center"
-            justifyContent="space-between"
-            sx={{ width: "100%", maxWidth: 640 }}
-          >
-            <Typography variant="body2" color="warning.main">
-              Warning: this runs on all servers and may download many files.
-            </Typography>
-            <Button
-              color="secondary"
-              startIcon={<InfoOutlinedIcon />}
-              variant="contained"
-              onClick={handleShowDownloadSetup}
-            >
-              Download Setup
-            </Button>
-          </Stack>
-
-          <Stack
-            direction="row"
-            alignItems="center"
-            justifyContent="space-between"
-            sx={{ width: "100%", maxWidth: 640 }}
-          >
-            <Stack direction="row" alignItems="center" spacing={1}>
-              <Button
-                color="secondary"
-                variant="contained"
-                onClick={handleImportManifest}
-                disabled={isExporting}
-              >
-                Import Manifest
-              </Button>
-              <Button
-                color="secondary"
-                variant="outlined"
-                onClick={handleClearManifest}
-                disabled={isExporting}
-              >
-                Clear Manifest
-              </Button>
-              <Typography variant="body2" color="text.secondary">
-                {importedManifest.length} imported item(s)
-              </Typography>
-            </Stack>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={downloadAssets}
-                  onChange={(event) => setDownloadAssets(event.target.checked)}
-                  disabled={isExporting}
-                />
-              }
-              label="Download Files"
-            />
-          </Stack>
-
-          <Stack
-            direction="row"
-            alignItems="center"
-            justifyContent="space-between"
-            sx={{ width: "100%", maxWidth: 640 }}
-          >
-            <Typography variant="body2" color="text.secondary">
-              Asset Type
-            </Typography>
-            <ToggleButtonGroup
-              exclusive
-              value={assetMode}
-              onChange={(_, value: ExportAssetMode | null) => {
-                if (!value || isExporting) return;
-                setAssetMode(value);
+              sx={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "center",
+                alignItems: "center",
+                gap: 0.5,
+                mt: 0.25,
               }}
-              size="small"
             >
-              <ToggleButton value="emoji">Emojis</ToggleButton>
-              <ToggleButton value="sticker">Stickers</ToggleButton>
-              <ToggleButton value="both">Both</ToggleButton>
-            </ToggleButtonGroup>
-          </Stack>
+              <Box
+                className={classNames({
+                  "operation-running": instruction === EmojiInstruction.EXPORTING,
+                })}
+              >
+                {getInstructionIcon()}
+              </Box>
+              <Typography variant="h6">{instruction}</Typography>
+            </Box>
 
-          <input
-            accept=".json,application/json"
-            onChange={handleManifestFileChange}
-            ref={fileInputRef}
-            style={{ display: "none" }}
-            type="file"
-          />
-
-          <Box
-            sx={{
-              width: "100%",
-              maxWidth: 640,
-              height: 320,
-              backgroundColor: "background.paper",
-            }}
-          >
-            <FixedSizeList
-              height={320}
-              width={640}
-              itemSize={36}
-              itemCount={logs.length}
+            <Stack
+              direction="row"
+              alignItems="flex-start"
+              justifyContent="space-between"
+              gap={1.5}
+              sx={{ width: "100%", maxWidth: 640, flexWrap: "wrap", rowGap: 1 }}
             >
-              {getLogRow}
-            </FixedSizeList>
+              <Stack direction="row" alignItems="flex-start" spacing={1} flexWrap="wrap">
+                <Stack spacing={0.5} sx={{ minWidth: 132 }}>
+                  <Button
+                    color="secondary"
+                    variant="contained"
+                    onClick={handleImportManifest}
+                    disabled={isExporting}
+                  >
+                    Import Manifest
+                  </Button>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ pl: 0.5 }}
+                  >
+                    {importedManifest.length} imported item(s)
+                  </Typography>
+                </Stack>
+                <Button
+                  color="secondary"
+                  variant="outlined"
+                  onClick={handleClearManifest}
+                  disabled={isExporting}
+                >
+                  Clear Manifest
+                </Button>
+              </Stack>
+
+              <Stack
+                direction="row"
+                alignItems="center"
+                spacing={1}
+                sx={{ flexWrap: "wrap", rowGap: 0.5, justifyContent: "flex-end" }}
+              >
+                <Typography variant="body2" color="text.secondary">
+                  Workers
+                </Typography>
+                <TextField
+                  value={workerCountInput}
+                  onChange={(event) => setWorkerCountInput(event.target.value)}
+                  onBlur={() =>
+                    setWorkerCountInput(String(parseWorkerCount(workerCountInput)))
+                  }
+                  disabled={isExporting}
+                  size="small"
+                  type="number"
+                  inputProps={{
+                    min: MIN_WORKER_COUNT,
+                    max: MAX_WORKER_COUNT,
+                    step: 1,
+                    inputMode: "numeric",
+                  }}
+                  sx={{
+                    width: 84,
+                    "& .MuiInputBase-input": {
+                      py: 0.75,
+                    },
+                  }}
+                />
+                <Typography variant="caption" color="text.secondary">
+                  Recommended: 1-8
+                </Typography>
+              </Stack>
+            </Stack>
+
+            <Stack
+              sx={{ width: "100%", maxWidth: 640, gap: 0.25 }}
+            >
+              <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+                gap={1}
+                sx={{ flexWrap: "wrap" }}
+              >
+                <FormControlLabel
+                  sx={{ ml: 0, mr: 0 }}
+                  control={
+                    <Checkbox
+                      checked={generateMetaFiles}
+                      onChange={(event) =>
+                        setGenerateMetaFiles(event.target.checked)
+                      }
+                      disabled={isExporting}
+                    />
+                  }
+                  label="Generate Meta Files"
+                />
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{
+                    flex: 1,
+                    minWidth: 220,
+                    textAlign: { xs: "left", sm: "right" },
+                    whiteSpace: { xs: "normal", sm: "nowrap" },
+                  }}
+                >
+                  Creates a JSON file for website asset categorization.
+                </Typography>
+              </Stack>
+
+              <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+                gap={1}
+                sx={{ flexWrap: "wrap" }}
+              >
+                <FormControlLabel
+                  sx={{ ml: 0, mr: 0 }}
+                  control={
+                    <Checkbox
+                      checked={includeStickers}
+                      onChange={(event) => setIncludeStickers(event.target.checked)}
+                      disabled={isExporting}
+                    />
+                  }
+                  label="Include Stickers"
+                />
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ flex: 1, minWidth: 200, textAlign: { xs: "left", sm: "right" } }}
+                >
+                  {includeStickers ? "Asset type: emojis + stickers." : "Asset type: emojis only."}
+                </Typography>
+              </Stack>
+            </Stack>
+
+            <input
+              accept=".json,application/json"
+              onChange={handleManifestFileChange}
+              ref={fileInputRef}
+              style={{ display: "none" }}
+              type="file"
+            />
+
+            <Box
+              sx={{
+                width: "100%",
+                maxWidth: 640,
+                height: 265,
+                backgroundColor: "background.paper",
+                borderRadius: 1,
+                overflow: "hidden",
+                flexShrink: 0,
+                minHeight: 265,
+                mt: 0.5,
+              }}
+            >
+              <FixedSizeList
+                height={265}
+                width="100%"
+                itemSize={32}
+                itemCount={logs.length}
+              >
+                {getLogRow}
+              </FixedSizeList>
+            </Box>
           </Box>
 
           <Stack
             direction="row"
             spacing={2}
-            justifyContent="flex-end"
+            justifyContent="space-between"
             alignItems="center"
+            sx={{ width: "100%", mt: 1, flexShrink: 0, pb: 0.5, gap: 1 }}
           >
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ flex: 1, minWidth: 0 }}
+            >
+              Added {exportProgress.added} new assets. Downloaded {exportProgress.downloaded}. Failed {exportProgress.failed}. Guilds {exportProgress.processedGuilds}/{exportProgress.totalGuilds}.
+            </Typography>
+            <Stack direction="row" spacing={2} alignItems="center">
             <Button
               color="secondary"
               variant="contained"
@@ -960,6 +1498,7 @@ const EmojiExportButton = ({
             >
               Export
             </Button>
+            </Stack>
           </Stack>
         </DialogContent>
       </Dialog>

--- a/src/containers/emoji-export-button/emoji-export-button.tsx
+++ b/src/containers/emoji-export-button/emoji-export-button.tsx
@@ -1,0 +1,970 @@
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogContent,
+  FormControlLabel,
+  ListItem,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from "@mui/material";
+import { FixedSizeList, ListChildComponentProps } from "react-window";
+import SmartToyIcon from "@mui/icons-material/SmartToy";
+import ConstructionIcon from "@mui/icons-material/Construction";
+import TaskAltIcon from "@mui/icons-material/TaskAlt";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import classNames from "classnames";
+import EnhancedDialogTitle from "../../common-components/enhanced-dialog/enhanced-dialog-title.tsx";
+import { useGuildSlice } from "../../features/guild/use-guild-slice.ts";
+import { useUserSlice } from "../../features/user/use-user-slice.ts";
+import DiscordService from "../../services/discord-service.ts";
+import { useAppSlice } from "../../features/app/use-app-slice.ts";
+import { getOsSafeString } from "../../utils.ts";
+import { nanoid } from "nanoid";
+import { DiscrubSetting } from "../../enum/discrub-setting.ts";
+import { AppSettings } from "../../features/app/app-types.ts";
+import "../purge-button/css/purge-status-header.css";
+
+type EmojiExportButtonProps = {
+  disabled?: boolean;
+  showTrigger?: boolean;
+  openSignal?: number;
+};
+
+type LogLevel = "info" | "ok" | "error";
+
+type LogEntry = {
+  id: string;
+  text: string;
+  level: LogLevel;
+};
+
+type AssetType = "emoji" | "sticker";
+
+type ManifestItem = {
+  type: AssetType;
+  id: Snowflake;
+  key: string;
+  name: string;
+  ext: string;
+  url: string;
+  file: string;
+  guildId: Snowflake;
+  guildName: string;
+};
+
+type ExportAssetMode = "emoji" | "sticker" | "both";
+
+type EmojiAssetCandidate = {
+  type: AssetType;
+  id: Snowflake;
+  key: string;
+  name: string;
+  ext: string;
+  baseUrl: string;
+  downloadUrl: string;
+  file: string;
+  guildId: Snowflake;
+  guildName: string;
+};
+
+type EmojiExportResumeState = {
+  version: 1;
+  nextGuildId?: Snowflake;
+  seenKeys: string[];
+  manifest: ManifestItem[];
+  updatedAt: number;
+};
+
+enum EmojiInstruction {
+  AWAITING_INSTRUCTION = "Awaiting Instruction",
+  EXPORTING = "Exporting Emojis",
+  OPERATION_COMPLETE = "Operation Complete",
+  OPERATION_FAILED = "Operation Failed",
+}
+
+const LOG_LIMIT = 1200;
+const EMOJI_EXPORT_RESUME_KEY = "discrub_emoji_export_resume_v1";
+const GUILD_FETCH_TIMEOUT_MS = 15000;
+const DOWNLOAD_TIMEOUT_MS = 12000;
+const EMOJI_DOWNLOAD_BATCH_SIZE = 8;
+
+const INVALID_FILE_CHARS = /[<>:"/\\|?*\x00-\x1F]/g;
+
+const cleanAssetName = (value: string) =>
+  String(value || "")
+    .replace(/^:+|:+$/g, "")
+    .replace(/^Sticker,\s*/i, "")
+    .replace(INVALID_FILE_CHARS, "_")
+    .replace(/\s+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 80) || "asset";
+
+const getStickerExt = (formatType?: number): string => {
+  switch (formatType) {
+    case 4:
+      return "gif";
+    case 3:
+      return "json";
+    case 2:
+      return "png";
+    default:
+      return "webp";
+  }
+};
+
+const modeAllowsType = (mode: ExportAssetMode, type: AssetType) => {
+  if (mode === "both") return true;
+  return mode === type;
+};
+
+const stripQuery = (url: string) => {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return url.split("?")[0];
+  }
+};
+
+const downloadBlob = (fileName: string, blob: Blob) => {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1500);
+};
+
+const downloadWithChromeApi = async (url: string, filename: string) => {
+  const downloads = globalThis.chrome?.downloads;
+  if (!downloads?.download) {
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    downloads.download(
+      {
+        url,
+        filename,
+        saveAs: false,
+        conflictAction: "uniquify",
+      },
+      (downloadId) => {
+        const errorMessage = globalThis.chrome?.runtime?.lastError?.message;
+        if (errorMessage || typeof downloadId !== "number") {
+          reject(
+            new Error(errorMessage || `Download failed for ${filename}`),
+          );
+          return;
+        }
+        resolve();
+      },
+    );
+  });
+};
+
+const withTimeout = async <T,>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> => {
+  let timeoutId: number | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = window.setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (typeof timeoutId === "number") {
+      window.clearTimeout(timeoutId);
+    }
+  }
+};
+
+const normalizeManifestItem = (item: unknown): ManifestItem | null => {
+  if (!item || typeof item !== "object") return null;
+  const source = item as Record<string, unknown>;
+
+  const type =
+    source.type === "sticker"
+      ? "sticker"
+      : source.type === "emoji"
+        ? "emoji"
+        : null;
+
+  if (
+    !type ||
+    typeof source.id !== "string" ||
+    typeof source.key !== "string" ||
+    typeof source.name !== "string" ||
+    typeof source.ext !== "string" ||
+    typeof source.url !== "string" ||
+    typeof source.file !== "string"
+  ) {
+    return null;
+  }
+
+  const normalizedType: AssetType = type === "emoji" ? "emoji" : "sticker";
+  return {
+    type: normalizedType,
+    id: source.id,
+    key: source.key,
+    name: source.name,
+    ext: source.ext,
+    url: stripQuery(source.url),
+    file: source.file,
+    guildId: typeof source.guildId === "string" ? source.guildId : "",
+    guildName: typeof source.guildName === "string" ? source.guildName : "",
+  };
+};
+
+const getChromeStorage = () => globalThis.chrome?.storage?.local;
+
+const loadResumeState = async (): Promise<EmojiExportResumeState | null> => {
+  const storage = getChromeStorage();
+  if (!storage) return null;
+
+  const payload = await storage.get(EMOJI_EXPORT_RESUME_KEY);
+  const raw = payload[EMOJI_EXPORT_RESUME_KEY] as unknown;
+  if (!raw || typeof raw !== "object") return null;
+
+  const data = raw as Partial<EmojiExportResumeState>;
+  if (
+    data.version !== 1 ||
+    !Array.isArray(data.seenKeys) ||
+    !Array.isArray(data.manifest)
+  ) {
+    return null;
+  }
+
+  const manifest = data.manifest
+    .map((item) => normalizeManifestItem(item))
+    .filter((item): item is ManifestItem => item !== null);
+
+  const seenKeys = data.seenKeys.filter(
+    (key): key is string => typeof key === "string" && key.includes(":"),
+  );
+
+  return {
+    version: 1,
+    nextGuildId:
+      typeof data.nextGuildId === "string" ? data.nextGuildId : undefined,
+    seenKeys,
+    manifest,
+    updatedAt:
+      typeof data.updatedAt === "number" ? data.updatedAt : Date.now(),
+  };
+};
+
+const saveResumeState = async (state: EmojiExportResumeState) => {
+  const storage = getChromeStorage();
+  if (!storage) return;
+  await storage.set({ [EMOJI_EXPORT_RESUME_KEY]: state });
+};
+
+const clearResumeState = async () => {
+  const storage = getChromeStorage();
+  if (!storage) return;
+  await storage.remove(EMOJI_EXPORT_RESUME_KEY);
+};
+
+const EmojiExportButton = ({
+  disabled = false,
+  showTrigger = true,
+  openSignal,
+}: EmojiExportButtonProps) => {
+  const { state: guildState, getGuilds } = useGuildSlice();
+  const guilds = guildState.guilds();
+  const guildLoading = guildState.isLoading();
+
+  const { state: userState } = useUserSlice();
+  const token = userState.token();
+
+  const { state: appState } = useAppSlice();
+  const settings = appState.settings();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [instruction, setInstruction] = useState<EmojiInstruction>(
+    EmojiInstruction.AWAITING_INSTRUCTION,
+  );
+  const [isExporting, setIsExporting] = useState(false);
+  const [stopRequested, setStopRequested] = useState(false);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [downloadAssets, setDownloadAssets] = useState(true);
+  const [assetMode, setAssetMode] = useState<ExportAssetMode>("emoji");
+  const [importedManifest, setImportedManifest] = useState<ManifestItem[]>([]);
+
+  const abortRef = useRef(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const lastOpenSignalRef = useRef<number | undefined>(openSignal);
+
+  const sortedGuilds = useMemo(
+    () => [...guilds].sort((a, b) => a.name.localeCompare(b.name)),
+    [guilds],
+  );
+
+  useEffect(() => {
+    if (token && !guildLoading && guilds.length === 0) {
+      getGuilds();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token, guildLoading, guilds.length]);
+
+  useEffect(() => {
+    if (
+      typeof openSignal === "number" &&
+      openSignal !== lastOpenSignalRef.current
+    ) {
+      setDialogOpen(true);
+    }
+    lastOpenSignalRef.current = openSignal;
+  }, [openSignal]);
+
+  const appendLog = (text: string, level: LogLevel = "info") => {
+    setLogs((prevState) =>
+      [{ id: nanoid(), text, level }, ...prevState].slice(0, LOG_LIMIT),
+    );
+  };
+
+  const getLogRow = ({ index, style }: ListChildComponentProps) => {
+    const row = logs[index];
+    const color =
+      row.level === "ok"
+        ? "success.main"
+        : row.level === "error"
+          ? "error.main"
+          : "text.primary";
+
+    return (
+      <ListItem style={style} key={row.id} dense divider>
+        <Typography variant="body2" sx={{ color, fontFamily: "monospace" }}>
+          {row.text}
+        </Typography>
+      </ListItem>
+    );
+  };
+
+  const handleClose = () => {
+    if (isExporting) {
+      if (stopRequested) {
+        return;
+      }
+      abortRef.current = true;
+      setStopRequested(true);
+      appendLog("Stop requested. Finishing current step...", "error");
+      return;
+    }
+    setDialogOpen(false);
+  };
+
+  const handleShowDownloadSetup = () => {
+    window.alert(
+      [
+        "Configure Chrome downloads before export:",
+        "1) Open a new tab manually: chrome://settings/downloads",
+        "2) Set your preferred Download location",
+        "3) Disable 'Ask where to save each file before downloading'",
+      ].join("\n"),
+    );
+  };
+
+  const handleImportManifest = () => {
+    if (!isExporting) {
+      fileInputRef.current?.click();
+    }
+  };
+
+  const handleManifestFileChange = async (
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+
+    if (!file) {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(await file.text());
+      if (!Array.isArray(parsed)) {
+        appendLog("Manifest must be a JSON array.", "error");
+        return;
+      }
+
+      const normalized = parsed
+        .map((item) => normalizeManifestItem(item))
+        .filter((item): item is ManifestItem => item !== null);
+
+      setImportedManifest(normalized);
+      appendLog(`Imported ${normalized.length} manifest item(s).`, "ok");
+    } catch (error) {
+      console.error(error);
+      appendLog("Manifest parse failed.", "error");
+    }
+  };
+
+  const handleClearManifest = async () => {
+    if (isExporting) return;
+    setImportedManifest([]);
+    try {
+      await clearResumeState();
+      appendLog("Manifest and resume state cleared.", "ok");
+    } catch (error) {
+      console.error(error);
+      appendLog("Manifest cleared, but failed to clear resume state.", "error");
+    }
+  };
+
+  const buildDownloadUrl = (
+    type: AssetType,
+    id: Snowflake,
+    ext: string,
+  ): { baseUrl: string; downloadUrl: string } => {
+    const folder = type === "emoji" ? "emojis" : "stickers";
+    const baseUrl = `https://cdn.discordapp.com/${folder}/${id}.${ext}`;
+
+    if (ext === "json") {
+      return { baseUrl, downloadUrl: baseUrl };
+    }
+
+    const url = new URL(baseUrl);
+    url.searchParams.set("quality", "lossless");
+    url.searchParams.set("size", type === "sticker" ? "320" : "160");
+    return { baseUrl, downloadUrl: url.toString() };
+  };
+
+  const handleExportEmojis = async () => {
+    if (!token || isExporting || !sortedGuilds.length) return;
+
+    const allowed = window.confirm(
+      "Export Emojis will scan all servers and may trigger many downloads. Make sure Chrome download folder settings are ready. Continue?",
+    );
+    if (!allowed) return;
+
+    const noDelaySettings: AppSettings = {
+      ...settings,
+      [DiscrubSetting.SEARCH_DELAY]: "0",
+      [DiscrubSetting.DELAY_MODIFIER]: "0",
+    };
+
+    const discordService = new DiscordService(noDelaySettings);
+    let startIndex = 0;
+    let resumeLoaded = false;
+    let resumeRestoreCount = 0;
+
+    const importedMap = new Map<string, ManifestItem>();
+    for (const item of importedManifest) {
+      if (!modeAllowsType(assetMode, item.type)) continue;
+      importedMap.set(item.key, item);
+    }
+
+    try {
+      const resumeState = await loadResumeState();
+      if (resumeState) {
+        resumeLoaded = true;
+        resumeRestoreCount = resumeState.manifest.filter((item) =>
+          modeAllowsType(assetMode, item.type),
+        ).length;
+        for (const item of resumeState.manifest) {
+          if (!modeAllowsType(assetMode, item.type)) continue;
+          importedMap.set(item.key, item);
+        }
+        if (resumeState.nextGuildId) {
+          const resumeIndex = sortedGuilds.findIndex(
+            (guild) => guild.id === resumeState.nextGuildId,
+          );
+          if (resumeIndex >= 0) {
+            startIndex = resumeIndex;
+          }
+        }
+      }
+    } catch (error) {
+      console.error(error);
+      appendLog("Resume state read failed. Starting from first guild.", "error");
+    }
+
+    const manifest: ManifestItem[] = Array.from(importedMap.values());
+    const seenKeys = new Set<string>(manifest.map((item) => item.key));
+
+    abortRef.current = false;
+    setLogs([]);
+    setIsExporting(true);
+    setStopRequested(false);
+    setInstruction(EmojiInstruction.EXPORTING);
+
+    appendLog(`Starting emoji export for ${sortedGuilds.length} guild(s).`);
+    appendLog(
+      downloadAssets
+        ? "Asset download enabled (files + manifest)."
+        : "Asset download disabled (manifest only).",
+    );
+    appendLog(
+      assetMode === "both"
+        ? "Asset mode: emojis + stickers."
+        : assetMode === "emoji"
+          ? "Asset mode: emojis only."
+          : "Asset mode: stickers only.",
+    );
+    if (resumeLoaded) {
+      appendLog(
+        `Resume loaded. Restored ${resumeRestoreCount} item(s). Starting from guild ${startIndex + 1}/${sortedGuilds.length}.`,
+        "ok",
+      );
+    }
+
+    let downloadOk = 0;
+    let downloadFail = 0;
+    let newEntries = 0;
+
+    const persistResume = async (nextIndex: number) => {
+      const nextGuildId =
+        nextIndex < sortedGuilds.length ? sortedGuilds[nextIndex].id : undefined;
+
+      await saveResumeState({
+        version: 1,
+        nextGuildId,
+        seenKeys: Array.from(seenKeys),
+        manifest,
+        updatedAt: Date.now(),
+      });
+    };
+
+    try {
+      await persistResume(startIndex);
+
+      for (let index = startIndex; index < sortedGuilds.length; index++) {
+        if (abortRef.current) break;
+
+        const guild = sortedGuilds[index];
+        appendLog(
+          `Scanning guild ${index + 1}/${sortedGuilds.length}: ${guild.name}`,
+        );
+
+        let guildResponse: DiscordApiResponse<{
+          name: string;
+          emojis?: { id: Snowflake | Maybe; name: string | Maybe; animated?: boolean }[];
+          stickers?: { id: Snowflake; name: string; format_type?: number }[];
+        }>;
+        try {
+          guildResponse = await withTimeout(
+            discordService.fetchGuildAssetData(token, guild.id),
+            GUILD_FETCH_TIMEOUT_MS,
+            "Guild asset request timed out.",
+          );
+        } catch (error) {
+          console.error(error);
+          appendLog(`[ERR] ${guild.name} -> guild request timeout`, "error");
+          continue;
+        }
+
+        if (!guildResponse.success || !guildResponse.data) {
+          const reason =
+            guildResponse.status === 403
+              ? "no permission"
+              : "unable to fetch guild assets";
+          appendLog(`[ERR] ${guild.name} -> ${reason}`, "error");
+          continue;
+        }
+
+        const guildName = guildResponse.data.name || guild.name;
+        const emojis = guildResponse.data.emojis || [];
+        const stickers = guildResponse.data.stickers || [];
+
+        let guildAdded = 0;
+        const candidates: EmojiAssetCandidate[] = [];
+
+        if (assetMode !== "sticker") {
+          for (const emoji of emojis) {
+            if (abortRef.current) break;
+            if (!emoji.id) continue;
+
+            const type: AssetType = "emoji";
+            const id = emoji.id;
+            const ext = emoji.animated ? "gif" : "webp";
+            const key = `${type}:${id}`;
+            if (seenKeys.has(key)) continue;
+
+            const name = cleanAssetName(emoji.name || `${type}_${id}`);
+            const file = `${type}_${name}_${id}.${ext}`;
+            const { baseUrl, downloadUrl } = buildDownloadUrl(type, id, ext);
+            candidates.push({
+              type: "emoji",
+              id,
+              key,
+              name,
+              ext,
+              baseUrl,
+              downloadUrl,
+              file,
+              guildId: guild.id,
+              guildName,
+            });
+          }
+        }
+
+        if (assetMode !== "emoji") {
+          for (const sticker of stickers) {
+            if (abortRef.current) break;
+            if (!sticker.id) continue;
+
+            const type: AssetType = "sticker";
+            const id = sticker.id;
+            const ext = getStickerExt(sticker.format_type);
+            const key = `${type}:${id}`;
+            if (seenKeys.has(key)) continue;
+
+            const name = cleanAssetName(sticker.name || `${type}_${id}`);
+            const file = `${type}_${name}_${id}.${ext}`;
+            const { baseUrl, downloadUrl } = buildDownloadUrl(type, id, ext);
+            candidates.push({
+              type: "sticker",
+              id,
+              key,
+              name,
+              ext,
+              baseUrl,
+              downloadUrl,
+              file,
+              guildId: guild.id,
+              guildName,
+            });
+          }
+        }
+
+        if (!downloadAssets) {
+          for (const candidate of candidates) {
+            seenKeys.add(candidate.key);
+            manifest.push({
+              type: candidate.type,
+              id: candidate.id,
+              key: candidate.key,
+              name: candidate.name,
+              ext: candidate.ext,
+              url: candidate.baseUrl,
+              file: candidate.file,
+              guildId: candidate.guildId,
+              guildName: candidate.guildName,
+            });
+            guildAdded += 1;
+            newEntries += 1;
+          }
+        } else {
+          for (
+            let start = 0;
+            start < candidates.length && !abortRef.current;
+            start += EMOJI_DOWNLOAD_BATCH_SIZE
+          ) {
+            const batch = candidates.slice(start, start + EMOJI_DOWNLOAD_BATCH_SIZE);
+            const batchResults = await Promise.all(
+              batch.map(async (candidate) => {
+                try {
+                  await withTimeout(
+                    downloadWithChromeApi(
+                      candidate.downloadUrl,
+                      `discrub-assets/${candidate.file}`,
+                    ),
+                    DOWNLOAD_TIMEOUT_MS,
+                    "Asset download timed out.",
+                  );
+                  return { ok: true as const, candidate };
+                } catch (error) {
+                  return { ok: false as const, candidate, error };
+                }
+              }),
+            );
+
+            for (const result of batchResults) {
+              if (result.ok) {
+                const candidate = result.candidate;
+                seenKeys.add(candidate.key);
+                manifest.push({
+                  type: candidate.type,
+                  id: candidate.id,
+                  key: candidate.key,
+                  name: candidate.name,
+                  ext: candidate.ext,
+                  url: candidate.baseUrl,
+                  file: candidate.file,
+                  guildId: candidate.guildId,
+                  guildName: candidate.guildName,
+                });
+                guildAdded += 1;
+                newEntries += 1;
+                downloadOk += 1;
+              } else {
+                console.error(result.error);
+                appendLog(`[ERR] Download failed: ${result.candidate.file}`, "error");
+                downloadFail += 1;
+              }
+            }
+          }
+        }
+
+        appendLog(`[OK] ${guild.name} -> added ${guildAdded} new asset(s).`, "ok");
+        try {
+          await persistResume(index + 1);
+        } catch (error) {
+          console.error(error);
+          appendLog("Resume state save failed for this checkpoint.", "error");
+        }
+      }
+
+      if (abortRef.current) {
+        appendLog("Export stopped. Progress saved for resume.", "error");
+      } else {
+        const manifestBlob = new Blob([JSON.stringify(manifest, null, 2)], {
+          type: "application/json",
+        });
+        const manifestName = `discord-assets-manifest-${getOsSafeString(
+          new Date().toISOString().replace(/:/g, "-"),
+        )}.json`;
+        downloadBlob(manifestName, manifestBlob);
+
+        appendLog(
+          `Manifest downloaded (${manifest.length} total, ${newEntries} new).`,
+          "ok",
+        );
+
+        if (downloadAssets) {
+          appendLog(
+            `Asset downloads complete. Success: ${downloadOk}, Failed: ${downloadFail}.`,
+            downloadFail ? "error" : "ok",
+          );
+        }
+
+        try {
+          await clearResumeState();
+        } catch (error) {
+          console.error(error);
+          appendLog("Could not clear resume state after completion.", "error");
+        }
+      }
+
+      setInstruction(
+        abortRef.current
+          ? EmojiInstruction.OPERATION_FAILED
+          : EmojiInstruction.OPERATION_COMPLETE,
+      );
+    } catch (error) {
+      console.error(error);
+      appendLog("Emoji export failed due to unexpected error.", "error");
+      setInstruction(EmojiInstruction.OPERATION_FAILED);
+    } finally {
+      setIsExporting(false);
+      setStopRequested(false);
+      abortRef.current = false;
+    }
+  };
+
+  const getInstructionIcon = () => {
+    if (instruction === EmojiInstruction.EXPORTING) {
+      return <ConstructionIcon />;
+    }
+    if (instruction === EmojiInstruction.OPERATION_COMPLETE) {
+      return <TaskAltIcon />;
+    }
+    if (instruction === EmojiInstruction.OPERATION_FAILED) {
+      return <ErrorOutlineIcon />;
+    }
+    return <SmartToyIcon />;
+  };
+
+  return (
+    <>
+      {showTrigger ? (
+        <Button
+          disabled={disabled || !token || (!guilds.length && !guildLoading)}
+          onClick={() => setDialogOpen(true)}
+          variant="contained"
+        >
+          Export Emojis
+        </Button>
+      ) : null}
+
+      <Dialog
+        hideBackdrop
+        PaperProps={{ sx: { minWidth: "680px", minHeight: "540px" } }}
+        open={dialogOpen}
+      >
+        <EnhancedDialogTitle title="Export Emojis" onClose={handleClose} />
+        <DialogContent
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "flex-start",
+            gap: 1,
+            alignItems: "center",
+          }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "center",
+              alignItems: "center",
+              gap: 0.5,
+            }}
+          >
+            <Box
+              className={classNames({
+                "operation-running": instruction === EmojiInstruction.EXPORTING,
+              })}
+            >
+              {getInstructionIcon()}
+            </Box>
+            <Typography variant="h6">{instruction}</Typography>
+          </Box>
+
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            sx={{ width: "100%", maxWidth: 640 }}
+          >
+            <Typography variant="body2" color="warning.main">
+              Warning: this runs on all servers and may download many files.
+            </Typography>
+            <Button
+              color="secondary"
+              startIcon={<InfoOutlinedIcon />}
+              variant="contained"
+              onClick={handleShowDownloadSetup}
+            >
+              Download Setup
+            </Button>
+          </Stack>
+
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            sx={{ width: "100%", maxWidth: 640 }}
+          >
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Button
+                color="secondary"
+                variant="contained"
+                onClick={handleImportManifest}
+                disabled={isExporting}
+              >
+                Import Manifest
+              </Button>
+              <Button
+                color="secondary"
+                variant="outlined"
+                onClick={handleClearManifest}
+                disabled={isExporting}
+              >
+                Clear Manifest
+              </Button>
+              <Typography variant="body2" color="text.secondary">
+                {importedManifest.length} imported item(s)
+              </Typography>
+            </Stack>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={downloadAssets}
+                  onChange={(event) => setDownloadAssets(event.target.checked)}
+                  disabled={isExporting}
+                />
+              }
+              label="Download Files"
+            />
+          </Stack>
+
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            sx={{ width: "100%", maxWidth: 640 }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              Asset Type
+            </Typography>
+            <ToggleButtonGroup
+              exclusive
+              value={assetMode}
+              onChange={(_, value: ExportAssetMode | null) => {
+                if (!value || isExporting) return;
+                setAssetMode(value);
+              }}
+              size="small"
+            >
+              <ToggleButton value="emoji">Emojis</ToggleButton>
+              <ToggleButton value="sticker">Stickers</ToggleButton>
+              <ToggleButton value="both">Both</ToggleButton>
+            </ToggleButtonGroup>
+          </Stack>
+
+          <input
+            accept=".json,application/json"
+            onChange={handleManifestFileChange}
+            ref={fileInputRef}
+            style={{ display: "none" }}
+            type="file"
+          />
+
+          <Box
+            sx={{
+              width: "100%",
+              maxWidth: 640,
+              height: 320,
+              backgroundColor: "background.paper",
+            }}
+          >
+            <FixedSizeList
+              height={320}
+              width={640}
+              itemSize={36}
+              itemCount={logs.length}
+            >
+              {getLogRow}
+            </FixedSizeList>
+          </Box>
+
+          <Stack
+            direction="row"
+            spacing={2}
+            justifyContent="flex-end"
+            alignItems="center"
+          >
+            <Button
+              color="secondary"
+              variant="contained"
+              onClick={handleClose}
+              disabled={isExporting && stopRequested}
+            >
+              {isExporting ? (stopRequested ? "Stopping..." : "Stop") : "Close"}
+            </Button>
+            <Button
+              disabled={isExporting || !sortedGuilds.length}
+              variant="contained"
+              onClick={handleExportEmojis}
+            >
+              Export
+            </Button>
+          </Stack>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default EmojiExportButton;

--- a/src/containers/emoji-export-button/emoji-export-postprocess.ts
+++ b/src/containers/emoji-export-button/emoji-export-postprocess.ts
@@ -1,0 +1,78 @@
+import { normalizeAssetExt } from "./emoji-export-asset-format.ts";
+
+export type PostprocessAssetInput = {
+  type: "emoji" | "sticker";
+  id: Snowflake;
+  name: string;
+  ext: string;
+  originalFile: string;
+  isAnimated: boolean;
+};
+
+export type EmojiMetaManifestRow = {
+  type: "emoji" | "sticker";
+  id: Snowflake;
+  name: string;
+  ext: string;
+  file: string;
+  url: string;
+};
+
+export type MetaOutput = {
+  manifestJson: string;
+  manifestJs: string;
+  existingFilesJs: string;
+  animatedWebpJs: string;
+};
+
+const slugify = (value: string) =>
+  String(value || "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9_-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase() || "asset";
+
+const writeAssignment = (variableName: string, value: unknown) =>
+  `window.${variableName} = ${JSON.stringify(value, null, 2)};\n`;
+
+export const buildWebsiteAssetFileName = (
+  type: "emoji" | "sticker",
+  name: string,
+  id: Snowflake,
+  ext: string,
+) => `${type}_${slugify(name)}_www.centrala.lgbt_${id}.${normalizeAssetExt(ext)}`;
+
+export const buildEmojiMetaFiles = async (
+  manifest: EmojiMetaManifestRow[],
+  renamedFiles: string[],
+  assets: PostprocessAssetInput[],
+): Promise<MetaOutput> => {
+  const existingFiles = [...renamedFiles].sort((a, b) =>
+    a.localeCompare(b, "en"),
+  );
+  const animatedWebpFiles: string[] = [];
+
+  for (const asset of assets) {
+    if (!asset.isAnimated) continue;
+    animatedWebpFiles.push(
+      buildWebsiteAssetFileName(asset.type, asset.name, asset.id, asset.ext),
+    );
+  }
+
+  animatedWebpFiles.sort((a, b) => a.localeCompare(b, "en"));
+
+  return {
+    manifestJson: `${JSON.stringify(manifest, null, 2)}\n`,
+    manifestJs: writeAssignment("__CENTRALA_EMOJI_MANIFEST", manifest),
+    existingFilesJs: writeAssignment(
+      "__CENTRALA_EMOJI_EXISTING_FILES",
+      existingFiles,
+    ),
+    animatedWebpJs: writeAssignment(
+      "__CENTRALA_ANIMATED_WEBP_FILES",
+      animatedWebpFiles,
+    ),
+  };
+};

--- a/src/containers/invite-export-button/invite-export-button.tsx
+++ b/src/containers/invite-export-button/invite-export-button.tsx
@@ -1,0 +1,576 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogContent,
+  ListItem,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { FixedSizeList, ListChildComponentProps } from "react-window";
+import SmartToyIcon from "@mui/icons-material/SmartToy";
+import ConstructionIcon from "@mui/icons-material/Construction";
+import TaskAltIcon from "@mui/icons-material/TaskAlt";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import classNames from "classnames";
+import EnhancedDialogTitle from "../../common-components/enhanced-dialog/enhanced-dialog-title.tsx";
+import { useGuildSlice } from "../../features/guild/use-guild-slice.ts";
+import { useUserSlice } from "../../features/user/use-user-slice.ts";
+import DiscordService from "../../services/discord-service.ts";
+import { useAppSlice } from "../../features/app/use-app-slice.ts";
+import { getOsSafeString } from "../../utils.ts";
+import { ChannelType } from "../../enum/channel-type.ts";
+import { nanoid } from "nanoid";
+import { DiscrubSetting } from "../../enum/discrub-setting.ts";
+import { AppSettings } from "../../features/app/app-types.ts";
+import "../purge-button/css/purge-status-header.css";
+
+type InviteExportButtonProps = {
+  disabled?: boolean;
+  showTrigger?: boolean;
+  openSignal?: number;
+};
+
+type LogLevel = "info" | "ok" | "error";
+
+type LogEntry = {
+  id: string;
+  text: string;
+  level: LogLevel;
+};
+
+type InviteResult = {
+  guildName: string;
+  inviteUrl?: string;
+  reason?: string;
+  ok: boolean;
+};
+
+enum InviteInstruction {
+  AWAITING_INSTRUCTION = "Awaiting Instruction",
+  EXPORTING = "Exporting Invites",
+  OPERATION_COMPLETE = "Operation Complete",
+  OPERATION_FAILED = "Operation Failed",
+}
+
+const LOG_LIMIT = 1200;
+
+const INVITE_CHANNEL_TYPES = new Set<number>([
+  ChannelType.GUILD_TEXT,
+  ChannelType.GUILD_VOICE,
+  ChannelType.GUILD_ANNOUNCEMENT,
+  ChannelType.GUILD_STAGE_VOICE,
+  ChannelType.GUILD_FORUM,
+  ChannelType.GUILD_MEDIA,
+]);
+const INVITE_FAST_CHANNEL_TYPES = new Set<number>([
+  ChannelType.GUILD_TEXT,
+  ChannelType.GUILD_ANNOUNCEMENT,
+  ChannelType.GUILD_FORUM,
+  ChannelType.GUILD_MEDIA,
+]);
+const INVITE_PERMISSION_BREAK_THRESHOLD = 12;
+
+const downloadTextFile = (fileName: string, text: string) => {
+  const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1500);
+};
+
+const buildInviteExportText = (results: InviteResult[]): string => {
+  const generated = new Date().toLocaleString();
+  const okCount = results.filter((result) => result.ok).length;
+  const failCount = results.length - okCount;
+
+  const lines: string[] = [
+    "Discord Invite Exporter",
+    "",
+    `Generated: ${generated}`,
+    `Guilds: ${results.length}  |  OK: ${okCount}  |  Failed: ${failCount}`,
+    "-------------------------------------",
+  ];
+
+  for (const result of results) {
+    if (result.ok && result.inviteUrl) {
+      lines.push(`[OK] ${result.guildName}`);
+      lines.push(result.inviteUrl);
+      lines.push("");
+    } else {
+      lines.push(`[ERR] ${result.guildName}`);
+      lines.push(result.reason || "unknown error");
+      lines.push("");
+    }
+  }
+
+  lines.push("-------------------------------------");
+  return lines.join("\n");
+};
+
+const normalizeInviteUrl = (value: string): string | null => {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+
+  if (raw.startsWith("https://discord.gg/")) return raw;
+  if (raw.startsWith("http://discord.gg/")) {
+    return raw.replace("http://discord.gg/", "https://discord.gg/");
+  }
+  if (raw.startsWith("https://discord.com/invite/")) {
+    const code = raw.split("/invite/")[1]?.split("?")[0];
+    return code ? `https://discord.gg/${code}` : null;
+  }
+  if (raw.startsWith("http://discord.com/invite/")) {
+    const code = raw.split("/invite/")[1]?.split("?")[0];
+    return code ? `https://discord.gg/${code}` : null;
+  }
+  if (/^[a-zA-Z0-9-]{2,}$/.test(raw)) {
+    return `https://discord.gg/${raw}`;
+  }
+  return null;
+};
+
+const InviteExportButton = ({
+  disabled = false,
+  showTrigger = true,
+  openSignal,
+}: InviteExportButtonProps) => {
+  const { state: guildState, getGuilds } = useGuildSlice();
+  const guilds = guildState.guilds();
+  const guildLoading = guildState.isLoading();
+
+  const { state: userState } = useUserSlice();
+  const token = userState.token();
+
+  const { state: appState } = useAppSlice();
+  const settings = appState.settings();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [instruction, setInstruction] = useState<InviteInstruction>(
+    InviteInstruction.AWAITING_INSTRUCTION,
+  );
+  const [isExporting, setIsExporting] = useState(false);
+  const [stopRequested, setStopRequested] = useState(false);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+
+  const abortRef = useRef(false);
+  const lastOpenSignalRef = useRef<number | undefined>(openSignal);
+
+  const sortedGuilds = useMemo(
+    () => [...guilds].sort((a, b) => a.name.localeCompare(b.name)),
+    [guilds],
+  );
+
+  useEffect(() => {
+    if (token && !guildLoading && guilds.length === 0) {
+      getGuilds();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token, guildLoading, guilds.length]);
+
+  useEffect(() => {
+    if (
+      typeof openSignal === "number" &&
+      openSignal !== lastOpenSignalRef.current
+    ) {
+      setDialogOpen(true);
+    }
+    lastOpenSignalRef.current = openSignal;
+  }, [openSignal]);
+
+  const appendLog = (text: string, level: LogLevel = "info") => {
+    setLogs((prevState) =>
+      [{ id: nanoid(), text, level }, ...prevState].slice(0, LOG_LIMIT),
+    );
+  };
+
+  const getLogRow = ({ index, style }: ListChildComponentProps) => {
+    const row = logs[index];
+    const color =
+      row.level === "ok"
+        ? "success.main"
+        : row.level === "error"
+          ? "error.main"
+          : "text.primary";
+
+    return (
+      <ListItem style={style} key={row.id} dense divider>
+        <Typography variant="body2" sx={{ color, fontFamily: "monospace" }}>
+          {row.text}
+        </Typography>
+      </ListItem>
+    );
+  };
+
+  const handleClose = () => {
+    if (isExporting) {
+      if (stopRequested) {
+        return;
+      }
+      abortRef.current = true;
+      setStopRequested(true);
+      appendLog("Stop requested. Finishing current step...", "error");
+      return;
+    }
+    setDialogOpen(false);
+  };
+
+  const handleShowDownloadSetup = () => {
+    window.alert(
+      [
+        "Configure Chrome downloads before export:",
+        "1) Open a new tab manually: chrome://settings/downloads",
+        "2) Set your preferred Download location",
+        "3) Disable 'Ask where to save each file before downloading'",
+      ].join("\n"),
+    );
+  };
+
+  const handleExportInvites = async () => {
+    if (!token || isExporting || !sortedGuilds.length) return;
+
+    const allowed = window.confirm(
+      "Export Invites will call Discord API across all servers and create a file download. Make sure Chrome download folder settings are ready. Continue?",
+    );
+    if (!allowed) return;
+
+    const noDelaySettings: AppSettings = {
+      ...settings,
+      [DiscrubSetting.SEARCH_DELAY]: "0",
+      [DiscrubSetting.DELAY_MODIFIER]: "0",
+    };
+
+    const discordService = new DiscordService(noDelaySettings);
+    const results: InviteResult[] = [];
+
+    abortRef.current = false;
+    setLogs([]);
+    setIsExporting(true);
+    setStopRequested(false);
+    setInstruction(InviteInstruction.EXPORTING);
+    appendLog(`Starting invite export for ${sortedGuilds.length} guild(s).`);
+
+    try {
+      for (let index = 0; index < sortedGuilds.length; index++) {
+        if (abortRef.current) break;
+
+        const guild = sortedGuilds[index];
+        appendLog(`Scanning guild ${index + 1}/${sortedGuilds.length}: ${guild.name}`);
+
+        const vanityResponse = await discordService.fetchGuildVanityInvite(
+          token,
+          guild.id,
+        );
+        const vanityCode = vanityResponse.data?.code || undefined;
+        if (vanityResponse.success && vanityCode) {
+          const inviteUrl = `https://discord.gg/${vanityCode}`;
+          results.push({ guildName: guild.name, ok: true, inviteUrl });
+          appendLog(`[OK] ${guild.name} -> ${inviteUrl} (vanity)`, "ok");
+          continue;
+        }
+
+        const guildDataResponse = await discordService.fetchGuildAssetData(
+          token,
+          guild.id,
+        );
+        const fallbackVanity = normalizeInviteUrl(
+          guildDataResponse.data?.vanity_url_code || "",
+        );
+        if (fallbackVanity) {
+          results.push({ guildName: guild.name, ok: true, inviteUrl: fallbackVanity });
+          appendLog(`[OK] ${guild.name} -> ${fallbackVanity} (guild data)`, "ok");
+          continue;
+        }
+
+        const widgetResponse = await discordService.fetchGuildWidget(
+          token,
+          guild.id,
+        );
+        const widgetInvite = normalizeInviteUrl(
+          widgetResponse.data?.instant_invite || "",
+        );
+        if (widgetInvite) {
+          results.push({ guildName: guild.name, ok: true, inviteUrl: widgetInvite });
+          appendLog(`[OK] ${guild.name} -> ${widgetInvite} (widget)`, "ok");
+          continue;
+        }
+
+        const channelsResponse = await discordService.fetchChannels(
+          token,
+          guild.id,
+        );
+        const channels = channelsResponse.data || [];
+
+        if (!channelsResponse.success || !channels.length) {
+          const reason =
+            channelsResponse.status === 403
+              ? "no permission"
+              : "unknown error on all channels";
+          results.push({ guildName: guild.name, ok: false, reason });
+          appendLog(`[ERR] ${guild.name} -> ${reason}`, "error");
+          continue;
+        }
+
+        const channelCandidates = channels
+          .filter((channel) => INVITE_CHANNEL_TYPES.has(channel.type))
+          .sort((a, b) => {
+            const aFast = INVITE_FAST_CHANNEL_TYPES.has(a.type) ? 0 : 1;
+            const bFast = INVITE_FAST_CHANNEL_TYPES.has(b.type) ? 0 : 1;
+            return aFast - bFast;
+          });
+        appendLog(
+          `Guild channels to test: ${channelCandidates.length}`,
+        );
+
+        let inviteUrl: string | undefined;
+        let permissionDenied = false;
+        let unknownErrors = 0;
+        let createdInvite = false;
+        let deniedStreak = 0;
+
+        for (let cIndex = 0; cIndex < channelCandidates.length; cIndex++) {
+          if (abortRef.current) break;
+
+          const channel = channelCandidates[cIndex];
+          if (cIndex % 25 === 0) {
+            appendLog(
+              `Invite lookup progress: ${cIndex + 1}/${channelCandidates.length}`,
+            );
+          }
+
+          const createInviteResponse = await discordService.createChannelInvite(
+            token,
+            channel.id,
+          );
+
+          if (createInviteResponse.success && createInviteResponse.data?.code) {
+            inviteUrl = `https://discord.gg/${createInviteResponse.data.code}`;
+            createdInvite = true;
+            break;
+          }
+
+          if (createInviteResponse.status === 403) {
+            permissionDenied = true;
+            deniedStreak += 1;
+          } else if (createInviteResponse.status) {
+            deniedStreak = 0;
+            unknownErrors += 1;
+          }
+
+          const response = await discordService.fetchChannelInvites(
+            token,
+            channel.id,
+          );
+          const invites = response.data || [];
+          const existingInvite = invites.find(
+            (invite) => typeof invite.code === "string" && invite.code.length > 0,
+          );
+
+          if (existingInvite?.code) {
+            inviteUrl = `https://discord.gg/${existingInvite.code}`;
+            break;
+          }
+
+          if (!response.success) {
+            if (response.status === 403) {
+              permissionDenied = true;
+              deniedStreak += 1;
+            } else {
+              deniedStreak = 0;
+              unknownErrors += 1;
+            }
+          } else {
+            deniedStreak = 0;
+          }
+
+          if (
+            deniedStreak >= INVITE_PERMISSION_BREAK_THRESHOLD &&
+            cIndex >= INVITE_PERMISSION_BREAK_THRESHOLD - 1
+          ) {
+            appendLog("[INFO] Early stop: repeated no-permission responses.");
+            break;
+          }
+        }
+
+        if (inviteUrl) {
+          results.push({ guildName: guild.name, ok: true, inviteUrl });
+          appendLog(
+            `[OK] ${guild.name} -> ${inviteUrl}${createdInvite ? " (created)" : ""}`,
+            "ok",
+          );
+        } else {
+          const reason =
+            permissionDenied && unknownErrors === 0
+              ? "no permission"
+              : unknownErrors === 0
+                ? "no invite found"
+                : "unknown error on channels";
+
+          results.push({ guildName: guild.name, ok: false, reason });
+          appendLog(`[ERR] ${guild.name} -> ${reason}`, "error");
+        }
+      }
+
+      if (results.length) {
+        const text = buildInviteExportText(results);
+        const fileName = `discord_invites_${getOsSafeString(
+          new Date().toISOString().replace(/:/g, "-"),
+        )}.txt`;
+        downloadTextFile(fileName, text);
+
+        const okCount = results.filter((result) => result.ok).length;
+        appendLog(
+          `Export file downloaded. OK: ${okCount}, Failed: ${results.length - okCount}.`,
+          "ok",
+        );
+      } else {
+        appendLog("No guild results to export.", "error");
+      }
+
+      setInstruction(
+        abortRef.current
+          ? InviteInstruction.OPERATION_FAILED
+          : InviteInstruction.OPERATION_COMPLETE,
+      );
+    } catch (error) {
+      console.error(error);
+      appendLog("Invite export failed due to unexpected error.", "error");
+      setInstruction(InviteInstruction.OPERATION_FAILED);
+    } finally {
+      setIsExporting(false);
+      setStopRequested(false);
+      abortRef.current = false;
+    }
+  };
+
+  const getInstructionIcon = () => {
+    if (instruction === InviteInstruction.EXPORTING) {
+      return <ConstructionIcon />;
+    }
+    if (instruction === InviteInstruction.OPERATION_COMPLETE) {
+      return <TaskAltIcon />;
+    }
+    if (instruction === InviteInstruction.OPERATION_FAILED) {
+      return <ErrorOutlineIcon />;
+    }
+    return <SmartToyIcon />;
+  };
+
+  return (
+    <>
+      {showTrigger ? (
+        <Button
+          disabled={disabled || !token || (!guilds.length && !guildLoading)}
+          onClick={() => setDialogOpen(true)}
+          variant="contained"
+        >
+          Export Invites
+        </Button>
+      ) : null}
+
+      <Dialog
+        hideBackdrop
+        PaperProps={{ sx: { minWidth: "600px", minHeight: "500px" } }}
+        open={dialogOpen}
+      >
+        <EnhancedDialogTitle title="Export Invites" onClose={handleClose} />
+        <DialogContent
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "flex-start",
+            gap: 1,
+            alignItems: "center",
+          }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "center",
+              alignItems: "center",
+              gap: 0.5,
+            }}
+          >
+            <Box
+              className={classNames({
+                "operation-running": instruction === InviteInstruction.EXPORTING,
+              })}
+            >
+              {getInstructionIcon()}
+            </Box>
+            <Typography variant="h6">{instruction}</Typography>
+          </Box>
+
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            sx={{ width: "100%", maxWidth: 560 }}
+          >
+            <Typography variant="body2" color="warning.main">
+              Warning: this runs on all servers and creates a download file.
+            </Typography>
+            <Button
+              color="secondary"
+              startIcon={<InfoOutlinedIcon />}
+              variant="contained"
+              onClick={handleShowDownloadSetup}
+            >
+              Download Setup
+            </Button>
+          </Stack>
+
+          <Box
+            sx={{
+              width: "100%",
+              maxWidth: 560,
+              height: 320,
+              backgroundColor: "background.paper",
+            }}
+          >
+            <FixedSizeList
+              height={320}
+              width={560}
+              itemSize={36}
+              itemCount={logs.length}
+            >
+              {getLogRow}
+            </FixedSizeList>
+          </Box>
+
+          <Stack
+            direction="row"
+            spacing={2}
+            justifyContent="flex-end"
+            alignItems="center"
+          >
+            <Button
+              color="secondary"
+              variant="contained"
+              onClick={handleClose}
+              disabled={isExporting && stopRequested}
+            >
+              {isExporting ? (stopRequested ? "Stopping..." : "Stop") : "Close"}
+            </Button>
+            <Button
+              disabled={isExporting || !sortedGuilds.length}
+              variant="contained"
+              onClick={handleExportInvites}
+            >
+              Export
+            </Button>
+          </Stack>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default InviteExportButton;

--- a/src/containers/invite-export-button/invite-export-button.tsx
+++ b/src/containers/invite-export-button/invite-export-button.tsx
@@ -201,7 +201,16 @@ const InviteExportButton = ({
 
     return (
       <ListItem style={style} key={row.id} dense divider>
-        <Typography variant="body2" sx={{ color, fontFamily: "monospace" }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color,
+            fontFamily: "monospace",
+            fontSize: "0.73rem",
+            lineHeight: 1.25,
+            wordBreak: "break-word",
+          }}
+        >
           {row.text}
         </Typography>
       </ListItem>
@@ -476,7 +485,16 @@ const InviteExportButton = ({
 
       <Dialog
         hideBackdrop
-        PaperProps={{ sx: { minWidth: "600px", minHeight: "500px" } }}
+        PaperProps={{
+          sx: {
+            minWidth: "600px",
+            width: "600px",
+            minHeight: "550px",
+            height: "550px",
+            maxHeight: "550px",
+            overflow: "hidden",
+          },
+        }}
         open={dialogOpen}
       >
         <EnhancedDialogTitle title="Export Invites" onClose={handleClose} />
@@ -533,12 +551,14 @@ const InviteExportButton = ({
               maxWidth: 560,
               height: 320,
               backgroundColor: "background.paper",
+              borderRadius: 1,
+              overflow: "hidden",
             }}
           >
             <FixedSizeList
               height={320}
-              width={560}
-              itemSize={36}
+              width="100%"
+              itemSize={32}
               itemCount={logs.length}
             >
               {getLogRow}

--- a/src/features/export/archive-writer.ts
+++ b/src/features/export/archive-writer.ts
@@ -1,0 +1,91 @@
+import streamSaver from "streamsaver";
+import { Writer } from "@transcend-io/conflux";
+
+type ArchiveEntryOptions = {
+  lastModified?: Date;
+};
+
+class ArchiveWriter {
+  private readable: ReadableStream;
+  private writable: WritableStream;
+  private writer: WritableStreamDefaultWriter<unknown>;
+  private fileStream: WritableStream<Uint8Array> | null = null;
+  private pipePromise: Promise<void> | null = null;
+  private closed = false;
+
+  constructor(private readonly fileName: string) {
+    const { readable, writable } = new Writer();
+    this.readable = readable;
+    this.writable = writable;
+    this.writer = this.writable.getWriter();
+    streamSaver.mitm = "resources/html/mitm.html";
+  }
+
+  private ensurePipe = () => {
+    if (!this.fileStream) {
+      this.fileStream = streamSaver.createWriteStream(this.fileName);
+    }
+
+    if (!this.pipePromise) {
+      const fileStream = this.fileStream!;
+      this.pipePromise = this.readable.pipeTo(fileStream);
+    }
+  };
+
+  addBlob = async (
+    blob: Blob,
+    filename: string,
+    options?: ArchiveEntryOptions,
+  ) => {
+    await this.addStream(
+      filename,
+      () => new Response(blob).body,
+      options,
+    );
+  };
+
+  addText = async (
+    text: string,
+    filename: string,
+    options?: ArchiveEntryOptions,
+  ) => {
+    await this.addBlob(new Blob([text], { type: "application/json" }), filename, options);
+  };
+
+  addStream = async (
+    filename: string,
+    createStream: () => ReadableStream<Uint8Array> | null,
+    options?: ArchiveEntryOptions,
+  ) => {
+    if (this.closed) {
+      throw new Error("Archive has already been finalized.");
+    }
+
+    const stream = createStream();
+    if (!stream) {
+      throw new Error(`Could not create stream for ${filename}`);
+    }
+
+    this.ensurePipe();
+    await this.writer.ready;
+    await this.writer.write({
+      name: filename,
+      lastModified: options?.lastModified || new Date(),
+      stream: () => stream,
+    });
+  };
+
+  close = async () => {
+    if (this.closed) return;
+
+    await this.writer.ready;
+    await this.writer.close();
+    this.closed = true;
+
+    if (this.pipePromise) {
+      await this.pipePromise;
+    }
+  };
+}
+
+export default ArchiveWriter;

--- a/src/global-types.d.ts
+++ b/src/global-types.d.ts
@@ -3,4 +3,6 @@ type Snowflake = string;
 type DiscordApiResponse<T = void> = {
   success: boolean;
   data?: T;
+  status?: number;
+  error?: unknown;
 };

--- a/src/global-types.d.ts
+++ b/src/global-types.d.ts
@@ -6,3 +6,7 @@ type DiscordApiResponse<T = void> = {
   status?: number;
   error?: unknown;
 };
+
+declare module "streamsaver";
+declare module "@transcend-io/conflux";
+declare module "gifenc";

--- a/src/services/discord-service.ts
+++ b/src/services/discord-service.ts
@@ -66,6 +66,38 @@ type SearchMessageResult = {
   total_results: number;
 };
 
+type ChannelInvite = {
+  code?: string;
+};
+
+type GuildVanityInvite = {
+  code?: string | null;
+};
+
+type GuildAssetEmoji = {
+  id: Snowflake | Maybe;
+  name: string | Maybe;
+  animated?: boolean;
+};
+
+type GuildAssetSticker = {
+  id: Snowflake;
+  name: string;
+  format_type?: number;
+};
+
+type GuildAssetData = {
+  id: Snowflake;
+  name: string;
+  vanity_url_code?: string | null;
+  emojis?: GuildAssetEmoji[];
+  stickers?: GuildAssetSticker[];
+};
+
+type GuildWidgetData = {
+  instant_invite?: string | null;
+};
+
 class DiscordService {
   searchDelaySecs = 0;
   deleteDelaySecs = 0;
@@ -139,10 +171,10 @@ class DiscordService {
             const data: T = isBlob
               ? await response.blob()
               : await response.json();
-            apiResponse = { success: true, data: data };
+            apiResponse = { success: true, data: data, status };
           } else {
             // Successful request does not have data
-            apiResponse = { success: true };
+            apiResponse = { success: true, status };
           }
         } else if (status === 429) {
           // Request must be re-attempted after x seconds
@@ -151,12 +183,14 @@ class DiscordService {
         } else {
           // Request failed for unknown reason
           requestComplete = true;
+          apiResponse = { success: false, status };
           console.error("Request could not be completed", response);
         }
       }
       return apiResponse;
     } catch (e) {
       console.error("Request threw an exception", e);
+      apiResponse = { success: false, status: 0, error: e };
       return apiResponse;
     }
   };
@@ -225,6 +259,20 @@ class DiscordService {
       }),
     );
 
+  fetchGuildAssetData = (authorization: string, guildId: string) =>
+    this.withSearchDelay(() =>
+      this.withRetry<GuildAssetData>(() =>
+        fetch(`${this.DISCORD_GUILDS_ENDPOINT}/${guildId}`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: authorization,
+            "user-agent": this.userAgent,
+          },
+        }),
+      ),
+    );
+
   fetchRoles = (guildId: string, authorization: string) =>
     this.withRetry<Role[]>(() =>
       fetch(`${this.DISCORD_GUILDS_ENDPOINT}/${guildId}/roles`, {
@@ -253,6 +301,68 @@ class DiscordService {
     this.withSearchDelay(() =>
       this.withRetry<Channel>(() =>
         fetch(`${this.DISCORD_CHANNELS_ENDPOINT}/${channelId}`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: authorization,
+            "user-agent": this.userAgent,
+          },
+        }),
+      ),
+    );
+
+  fetchChannelInvites = (authorization: string, channelId: string) =>
+    this.withSearchDelay(() =>
+      this.withRetry<ChannelInvite[]>(() =>
+        fetch(`${this.DISCORD_CHANNELS_ENDPOINT}/${channelId}/invites`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: authorization,
+            "user-agent": this.userAgent,
+          },
+        }),
+      ),
+    );
+
+  createChannelInvite = (authorization: string, channelId: string) =>
+    this.withSearchDelay(() =>
+      this.withRetry<ChannelInvite>(() =>
+        fetch(`${this.DISCORD_CHANNELS_ENDPOINT}/${channelId}/invites`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: authorization,
+            "user-agent": this.userAgent,
+          },
+          body: JSON.stringify({
+            max_age: 0,
+            max_uses: 0,
+            temporary: false,
+            unique: false,
+          }),
+        }),
+      ),
+    );
+
+  fetchGuildVanityInvite = (authorization: string, guildId: string) =>
+    this.withSearchDelay(() =>
+      this.withRetry<GuildVanityInvite>(() =>
+        fetch(`${this.DISCORD_GUILDS_ENDPOINT}/${guildId}/vanity-url`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: authorization,
+            "user-agent": this.userAgent,
+          },
+        }),
+      ),
+    );
+
+  fetchGuildWidget = (authorization: string, guildId: string) =>
+    this.withSearchDelay(() =>
+      this.withRetry<GuildWidgetData>(() =>
+        fetch(`${this.DISCORD_GUILDS_ENDPOINT}/${guildId}/widget.json`, {
           method: "GET",
           headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

This updates the fork of `prathercc/discrub-ext` with fork-specific export tooling and documentation.

The main goal is to document the fork honestly as a fork, preserve upstream credit, and describe the actual local changes that make this branch different from upstream.

## What changed

### Fork-specific export workflows
- added a dedicated **Export Invites** flow in the main menu
- added a dedicated **Export Emojis** flow in the main menu
- extended Discord service calls used by the fork-specific exporters
- added permissions needed for downloader/CDN access in the extension manifest

### Emoji/sticker export improvements
- ZIP-first archive workflow for asset export
- worker-pool processing for large guild sets
- manifest import and resume/checkpoint handling
- optional meta-file generation for downstream website ingestion
- normalized final asset output:
  - static image assets -> `png`
  - animated image assets -> `gif`
  - JSON/Lottie assets -> `json`
- improved exporter logging and dialog behavior

### Documentation
- replaced the generic upstream README with a fork-oriented README
- added a dedicated `FORK-CHANGES.md` describing the delta vs upstream
- added docs for:
  - invite export
  - emoji/sticker export
- updated existing docs so navigation and settings pages mention the fork-specific menu/actions without duplicating upstream docs unnecessarily

## Why

Upstream Discrub already covers message search/filter/export/purge workflows well.

This fork exists to support heavier archival/export use cases, especially:
- invite discovery across accessible guilds
- bulk emoji/sticker extraction
- browser-side archive packaging
- more predictable final asset formats
- better long-running exporter UX

## Notes

This PR keeps upstream attribution explicit and does not present the fork as the original project.

The fork-specific documentation is based on:
- the actual local repo state
- local upstream comparison against `origin/development`
- the session-log/reference folder used only as supporting evidence

## Validation

- `npm install`
- `npm run build`
